### PR TITLE
fix(devcontainer): Pin kubectl/helm versions to resolve build failures

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,11 @@
 	"workspaceFolder": "/workspace",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
-		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
+		"ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {
+			"version": "1.35.0",
+			"helm": "4.0.2",
+			"minikube": "none"
+		},
 		"ghcr.io/devcontainers/features/terraform:1": {},
 		"ghcr.io/devcontainers-extra/features/protoc:1": {},
     	"ghcr.io/42atomys/devcontainers-features/redis-cli:1": {}


### PR DESCRIPTION
## Problem

Dev container build was failing with GPG verification errors:
```
(*) Keyserver hkp://keyserver.pgp.com is not reachable.
Verification failed!
gpg: no valid OpenPGP data found.
ERROR: Feature "Kubectl, Helm, and Minikube" failed to install!
```

This is a known issue with the `kubectl-helm-minikube` devcontainer feature when using `"latest"` versions - keyservers are intermittently unreachable during signature verification.

## Solution

Pinned specific stable versions in `.devcontainer/devcontainer.json`:

- **kubectl**: `1.35.0` (latest stable as of January 2026)
- **helm**: `4.0.2` (latest stable Helm 4.x)
- **minikube**: `none` (not needed for this project)

## Testing

- [x] Dev container builds successfully