### PR TITLE
perf: frame buffer management

### DIFF
--- a/video-core/Makefile
+++ b/video-core/Makefile
@@ -1,7 +1,7 @@
 # DirectLink Video Core Makefile
 
 CXX := g++
-CXXFLAGS := -std=c++20 -Wall -Wextra -Wpedantic
+CXXFLAGS := -std=c++20 -Wall -Wextra -Wpedantic -g -fno-omit-frame-pointer
 LDFLAGS := $(shell pkg-config --libs libavcodec libavformat libavutil libswscale libavdevice)
 INCLUDES := -Iinclude $(shell pkg-config --cflags libavcodec libavformat libavutil libswscale libavdevice)
 

--- a/video-core/include/pipeline/video_pipeline.hpp
+++ b/video-core/include/pipeline/video_pipeline.hpp
@@ -60,6 +60,10 @@ public:
         return 0.0f;
     } // NOLINTEND(readability-convert-member-functions-to-static)
 
+    [[nodiscard]] int getDroppedFrames() const noexcept {
+        return framesDropped_.load();
+    }
+
 private:
     encode::EncoderConfig encoderConfig_;
     std::unique_ptr<capture::CameraCapture> captureDevice_;
@@ -68,6 +72,8 @@ private:
 
     // Frame queue  between capture and encode threads
     std::queue<std::unique_ptr<Frame>> frameQueue_;
+    static constexpr int QUEUE_CAPACITY = 3;
+    std::atomic<int> framesDropped_ = 0;
     std::mutex queueMutex_;
     std::condition_variable queueCondition_;
 

--- a/video-core/src/pipeline/video_pipeline.cpp
+++ b/video-core/src/pipeline/video_pipeline.cpp
@@ -52,10 +52,14 @@ Result VideoPipeline::start(
         captureDevice_->start([this](std::unique_ptr<Frame> frame) {
             {
                 std::lock_guard<std::mutex> lock(queueMutex_);
+                if (frameQueue_.size() >= QUEUE_CAPACITY) {
+                    frameQueue_.pop(); // Drop oldest frame
+                    framesDropped_++;
+                }
                 frameQueue_.push(std::move(frame));
             }
             queueCondition_.notify_one();
-            frameCount_++;
+            frameCount_++; // Counts all frames captured, including dropped ones
         });
     if (capture_result != Result::Success) {
         return capture_result; // Failed to start capture

--- a/video-core/tests/integration/test_nvenc_video_pipeline.cpp
+++ b/video-core/tests/integration/test_nvenc_video_pipeline.cpp
@@ -59,6 +59,7 @@ int main() {
     std::cout << "FPS:             " << pipeline.getFPS() << "\n";
     std::cout << "Bitrate:         " << pipeline.getBitrate() << " bps\n";
     std::cout << "Frames captured: " << pipeline.getFrameCount() << "\n";
+    std::cout << "Frames dropped:  " << pipeline.getDroppedFrames() << "\n";
     std::cout << "Packets encoded: " << packets_received.load() << "\n";
 
     float fps = pipeline.getFPS();

--- a/video-core/tests/integration/test_video_pipeline.cpp
+++ b/video-core/tests/integration/test_video_pipeline.cpp
@@ -54,6 +54,7 @@ int main() {
     std::cout << "FPS:             " << pipeline.getFPS() << "\n";
     std::cout << "Bitrate:         " << pipeline.getBitrate() << " bps\n";
     std::cout << "Frames captured: " << pipeline.getFrameCount() << "\n";
+    std::cout << "Frames dropped:  " << pipeline.getDroppedFrames() << "\n";
     std::cout << "Packets encoded: " << packets_received.load() << "\n";
 
     float fps = pipeline.getFPS();


### PR DESCRIPTION
## Summary
**Caps `frameQueue_` at a fixed size and drops the oldest frame when full, preventing latency buildup when the encoder falls behind the capture thread.**

## Problem
The existing `VideoPipeline` uses an unbounded `std::queue` between the capture and encode threads. Under sustained load or an encoder slowdown, the queue grows without limit. By the time those frames are encoded and transmitted, they're stale, the director sees video that's seconds behind reality, which defeats the purpose of a live feed.

## Solution
Adds a bounded queue with drop-oldest backpressure:
- `QUEUE_CAPACITY = 3` caps the queue at ~100ms of buffering at 30fps, leaving headroom for the rest of the pipeline to stay within the <150ms target
- When the queue is full, the oldest frame is dropped and the newest is pushed
- Dropped frames are tracked via `framesDropped_` and exposed through `getDroppedFrames()`
- If frames are consistently dropping under normal load, it signals encoder performance issues — not a reason to increase the queue size

## Changes
- `video_pipeline.hpp` — added `QUEUE_CAPACITY` constant, `framesDropped_` atomic, and `getDroppedFrames()` getter
- `video_pipeline.cpp` — updated capture callback to enforce queue bound and track drops
- `test_video_pipeline.cpp` — added `getDroppedFrames()` to integration test output

## Notes
- Only `VideoPipeline` is affected — `CameraCapture` and the encoders are unchanged
- `framesDropped_` should eventually be surfaced in the latency overlay on the director client