### PR TITLE
chore(app): app qt dependency change

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 
 project(direct-link VERSION 0.1 LANGUAGES CXX)
 
@@ -25,14 +25,16 @@ qt_add_executable(direct-link
         MANUAL_FINALIZATION
         ${PROJECT_SOURCES}
         resources.qrc
-        src/framereader.cpp
-        src/framereader.hpp
     )
 
 set(QML_IMPORT_PATH
-    ${CMAKE_BINARY_DIR}/src
+    ${CMAKE_BINARY_DIR}/qt/qml
     CACHE STRING "Qt Creator extra qml import paths" FORCE
 )
+
+# QTP0001: Changes default RESOURCE_PREFIX for qt_add_qml_module from "/"
+# to "qt/qml/". Removes the need to call addImportPath manually.
+qt_policy(SET QTP0001 NEW)
 
 add_subdirectory(src/application)
 add_subdirectory(src/ui)
@@ -41,7 +43,6 @@ add_subdirectory(src/ui/theme)
 
 target_include_directories(direct-link PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${FFMPEG_INCLUDE_DIRS}
 )
 
 target_link_libraries(direct-link PRIVATE
@@ -49,7 +50,6 @@ target_link_libraries(direct-link PRIVATE
     Qt6::Quick
     Qt6::QuickControls2
     Qt6::Multimedia
-    ${FFMPEG_LIBRARIES}
     directlink_appplugin
     directlink_uiplugin
     directlink_ui_controlsplugin

--- a/client/src/application/CMakeLists.txt
+++ b/client/src/application/CMakeLists.txt
@@ -1,18 +1,27 @@
 qt_add_library(directlink_app STATIC)
 
 set_target_properties(directlink_app PROPERTIES AUTOMOC ON)
+
+target_include_directories(directlink_app PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/..
+    ${FFMPEG_INCLUDE_DIRS}
+)
+
 target_link_libraries(directlink_app PRIVATE
     Qt6::Core
     Qt6::Quick
     Qt6::QuickControls2
     Qt6::Multimedia
+    ${FFMPEG_LIBRARIES}
 )
 
 qt_add_qml_module(directlink_app
     URI application
     VERSION 1.0
-    RESOURCE_PREFIX /src
     QML_FILES
         Main.qml
         SessionPage.qml
+    SOURCES
+        ${CMAKE_CURRENT_SOURCE_DIR}/../framereader.hpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../framereader.cpp
 )

--- a/client/src/framereader.cpp
+++ b/client/src/framereader.cpp
@@ -11,7 +11,7 @@
 
 
 
-FrameReader::FrameReader(QObject *parent) : QObject(parent), m_videoSink(nullptr) {
+FrameReader::FrameReader(QObject *parent) : QObject(parent) {
 
 }
 

--- a/client/src/framereader.hpp
+++ b/client/src/framereader.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <QObject>
+#include <QQmlEngine>
 #include <QImage>
 #include <QSize>
 #include <QVideoSink>
@@ -14,9 +15,16 @@ class FrameReader : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QVideoSink *videoSink READ videoSink WRITE setVideoSink NOTIFY videoSinkChanged)
+    QML_ELEMENT
+    QML_SINGLETON
 
 public:
     FrameReader(QObject *parent = nullptr);
+
+    static FrameReader *create(QQmlEngine *, QJSEngine *) {
+        static FrameReader instance;
+        return &instance;
+    }
 
     [[nodiscard]] QVideoSink *videoSink() const;
 
@@ -27,5 +35,5 @@ signals:
     void videoSinkChanged();
 
 private:
-    QVideoSink *m_videoSink;
+    QVideoSink *m_videoSink {nullptr};
 };

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -1,22 +1,13 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
-#include <QQmlContext>
 #include "framereader.hpp"
 
 int main(int argc, char *argv[])
 {
     QGuiApplication app(argc, argv);
-
     QQmlApplicationEngine engine;
 
-    engine.addImportPath("qrc:/src");
-
-    FrameReader frame_reader;
-    engine.rootContext()->setContextProperty("FrameReader", &frame_reader);
-
-    const QUrl url(QStringLiteral("qrc:/src/application/Main.qml"));
-
-    engine.load(url);
+    engine.loadFromModule("application", "Main");
 
     return app.exec();
 }

--- a/client/src/ui/CMakeLists.txt
+++ b/client/src/ui/CMakeLists.txt
@@ -10,7 +10,6 @@ target_link_libraries(directlink_ui PRIVATE
 qt_add_qml_module(directlink_ui
     URI ui
     VERSION 1.0
-    RESOURCE_PREFIX /src
     QML_FILES
         Header.qml
         Footer.qml

--- a/client/src/ui/controls/CMakeLists.txt
+++ b/client/src/ui/controls/CMakeLists.txt
@@ -11,7 +11,6 @@ target_link_libraries(directlink_ui_controls  PRIVATE
 qt_add_qml_module(directlink_ui_controls
     URI ui.controls
     VERSION 1.0
-    RESOURCE_PREFIX /src
     QML_FILES
         CameraFeed.qml
         SessionInfo.qml

--- a/client/src/ui/theme/CMakeLists.txt
+++ b/client/src/ui/theme/CMakeLists.txt
@@ -12,7 +12,6 @@ set_source_files_properties(Theme.qml PROPERTIES
 qt_add_qml_module(directlink_ui_theme
     URI ui.theme
     VERSION 1.0
-    RESOURCE_PREFIX /src
     QML_FILES
         Theme.qml
 )


### PR DESCRIPTION
### Summary

The application previously depended on C++ 17 and Qt 6.5.2. The application now depends on C++ 20 and Qt 6.10.2. The root CMakeLists.txt and subdirectories were updated to meet standards introduced in newer versions of Qt, but the app's functionality remains the same.

### Changes

- `client/CMakeLists.txt` requires a minimum CMake version of 3.16, and the `CMAKE_CXX_STANDARD` standard was updated to support C++ 20
- `client/src/application/CMakeLists.txt` now holds references to the `FrameReader` class and its dependencies
- `main.cpp` now uses the `loadFromModule` feature of QQmlApplicationEngine instead of loading from a URL