### PR TITLE
feat: add windows camera support

### DIFF
--- a/client/src/session/camera_session.cpp
+++ b/client/src/session/camera_session.cpp
@@ -8,8 +8,13 @@ bool CameraSession::start(const std::string &whipUrl,
     }
 
     videoCore::capture::CaptureConfig captureConfig;
-    captureConfig.devicePath = "/dev/video0";
-    captureConfig.inputFormat = "v4l2";
+    #ifdef _WIN32
+        captureConfig.devicePath = "video=0";
+        captureConfig.inputFormat = "dshow";
+    #else
+        captureConfig.devicePath = "/dev/video0";
+        captureConfig.inputFormat = "v4l2";
+    #endif
     captureConfig.width = 1920;
     captureConfig.height = 1080;
     captureConfig.framerate = 30;

--- a/video-core/include/capture/capture_config.hpp
+++ b/video-core/include/capture/capture_config.hpp
@@ -4,8 +4,9 @@
 
 namespace videoCore::capture {
 struct CaptureConfig {
-    std::string devicePath = "/dev/video0";
-    std::string inputFormat = "v4l2";
+    std::string devicePath =
+        "/dev/video0";                // Linux: /dev/video0, Windows: "video=0"
+    std::string inputFormat = "v4l2"; // Linux: v4l2, Windows: dshow
     int width = 0;
     int height = 0;
     int framerate = 30;

--- a/video-core/tests/integration/test_nvenc_video_pipeline.cpp
+++ b/video-core/tests/integration/test_nvenc_video_pipeline.cpp
@@ -8,7 +8,15 @@ int main() {
     videoCore::pipeline::VideoPipeline pipeline;
 
     videoCore::capture::CaptureConfig capture_config;
+#ifdef _WIN32
+    std::cout << "Choosing Windows camera configuration" << "\n";
+    capture_config.devicePath = "video=0";
+    capture_config.inputFormat = "dshow";
+#else
+    std::cout << "Choosing Linux camera configuration" << "\n";
     capture_config.devicePath = "/dev/video0";
+    capture_config.inputFormat = "v4l2";
+#endif
     capture_config.width = 640;
     capture_config.height = 480;
     capture_config.framerate = 30;

--- a/video-core/tests/integration/test_video_pipeline.cpp
+++ b/video-core/tests/integration/test_video_pipeline.cpp
@@ -8,7 +8,15 @@ int main() {
     videoCore::pipeline::VideoPipeline pipeline;
 
     videoCore::capture::CaptureConfig capture_config;
+#ifdef _WIN32
+    std::cout << "Choosing Windows camera configuration" << "\n";
+    capture_config.devicePath = "video=0";
+    capture_config.inputFormat = "dshow";
+#else
+    std::cout << "Choosing Linux camera configuration" << "\n";
     capture_config.devicePath = "/dev/video0";
+    capture_config.inputFormat = "v4l2";
+#endif
     capture_config.width = 640;
     capture_config.height = 480;
     capture_config.framerate = 30;


### PR DESCRIPTION
## Summary
Adds platform detection to the operator publish pipeline so camera capture 
works on both Linux (v4l2) and Windows (DirectShow). Previously the device 
path and input format were hardcoded to `/dev/video0` and `v4l2`, making 
the operator path non-functional on Windows native builds. A `#ifdef _WIN32` 
block now selects the correct backend at compile time with no runtime 
overhead.

## Changes
- `client/src/session/camera_session.cpp` — replaced hardcoded Linux capture 
config with `#ifdef _WIN32` block selecting `dshow`/`video=0` on Windows and 
`v4l2`/`/dev/video0` on Linux
- `video-core/include/capture/capture_config.hpp` — added comments to default 
values clarifying they are Linux-specific
- `video-core/tests/integration/test_video_pipeline.cpp` — same `#ifdef` 
applied to integration test capture config, with platform log line for 
debugging
- `video-core/tests/integration/test_nvenc_video_pipeline.cpp` — same change 
as above

## Notes
- The `_WIN32` block is dead code in the dev container — GCC on Linux never 
defines `_WIN32` so existing behavior and all tests are unchanged
- dshow availability is verified at runtime by `CameraCapture::setupDevice()` 
via `av_find_input_format("dshow")` — returns `ErrorInvalidParameter` cleanly 
if FFmpeg on Windows was not built with dshow support
- Windows FFmpeg build must include dshow support — gyan.dev full builds 
include it by default
- End-to-end testing on Windows requires a native build outside the dev 
container. Can be verified on a Windows with FFmpeg, CMake, and 
a C++20 compiler installed

## Acceptance Criteria
- Operator joins session on Linux → v4l2 path used, existing behavior 
unchanged
- Operator joins session on Windows → dshow path used, stream publishes 
to LiveKit
- No compilation errors on either platform

## Closes
Closes #158