### PR TITLE
feat: normalize PTS in CPU encoder

### DIFF
--- a/video-core/src/encode/software_encoder.cpp
+++ b/video-core/src/encode/software_encoder.cpp
@@ -110,6 +110,13 @@ Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
         }
     }
 
+    // Convert PTS from nanoseconds to encoder timebase
+    input_frame->pts =
+        av_rescale_q(frame->pts, // already nanoseconds from CameraCapture
+                     AVRational{1, 1000000000}, // from
+                     codecCtx_->time_base       // to encoder timebase
+        );
+
     // Send frame to encoder
     int ret = avcodec_send_frame(codecCtx_, input_frame);
     if (converted_frame != nullptr) {
@@ -124,8 +131,12 @@ Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
     while (avcodec_receive_packet(codecCtx_, pkt) == 0) {
         auto wrapped_packet = std::make_unique<Packet>();
         wrapped_packet->packet.reset(av_packet_clone(pkt));
-        wrapped_packet->pts = pkt->pts;
-        wrapped_packet->dts = pkt->dts;
+
+        // Convert PTS/DTS to nanoseconds
+        AVRational encoder_tb = codecCtx_->time_base;
+        wrapped_packet->pts = Encoder::rescaleToNs(pkt->pts, encoder_tb);
+        wrapped_packet->dts = Encoder::rescaleToNs(pkt->dts, encoder_tb);
+
         wrapped_packet->size = pkt->size;
         wrapped_packet->isKeyframe = (pkt->flags & AV_PKT_FLAG_KEY) != 0;
 
@@ -150,8 +161,12 @@ Result SoftwareEncoder::stop() {
     while (avcodec_receive_packet(codecCtx_, pkt) == 0) {
         auto wrapped_packet = std::make_unique<Packet>();
         wrapped_packet->packet.reset(av_packet_clone(pkt));
-        wrapped_packet->pts = pkt->pts;
-        wrapped_packet->dts = pkt->dts;
+
+        // Convert PTS/DTS to nanoseconds
+        AVRational encoder_tb = codecCtx_->time_base;
+        wrapped_packet->pts = Encoder::rescaleToNs(pkt->pts, encoder_tb);
+        wrapped_packet->dts = Encoder::rescaleToNs(pkt->dts, encoder_tb);
+
         wrapped_packet->size = pkt->size;
         wrapped_packet->isKeyframe = (pkt->flags & AV_PKT_FLAG_KEY) != 0;
         if (encodedPacketCallback_) {


### PR DESCRIPTION
## Summary
`SoftwareEncoder` was passing `pkt->pts` and `pkt->dts` directly through 
without rescaling, while `NVENCEncoder` correctly used `Encoder::rescaleToNs()` 
to convert from encoder timebase to nanoseconds. This inconsistency meant that 
when the software encoder was active, `videoCore::Packet::pts` arriving at 
`WHIPPublisher` was in raw encoder ticks rather than nanoseconds, causing 
`GST_BUFFER_PTS` to be set incorrectly. This would produce A/V sync problems 
and GStreamer buffer underruns the moment the pipeline ran end-to-end.

## Changes
- `software_encoder.cpp` — replaced direct `pkt->pts` / `pkt->dts` assignment 
in both `encodeFrame()` and `stop()` with `Encoder::rescaleToNs()` calls using 
`codecCtx_->time_base`, matching the existing implementation in `NVENCEncoder`

## Contract
`videoCore::Packet::pts` and `dts` are now guaranteed to be nanoseconds 
regardless of which encoder backend is active, consistent with the contract 
established in #146.

## Closes
Closes #164