### PR TITLE
feat: detect nvenc in createEncoder()

### DIFF
--- a/video-core/src/encode/encoder.cpp
+++ b/video-core/src/encode/encoder.cpp
@@ -2,7 +2,12 @@
 #include "../../include/encode/encoder_config.hpp"
 #include "../../include/encode/nvenc_encoder.hpp"
 #include "../../include/encode/software_encoder.hpp"
+
+extern "C" {
+#include <libavcodec/avcodec.h>
 #include <libavutil/mathematics.h>
+}
+
 namespace videoCore::encode {
 
 Result Encoder::initialize(
@@ -22,7 +27,22 @@ int64_t Encoder::rescaleToNs(int64_t value, AVRational src_tb) {
 }
 
 std::unique_ptr<Encoder> createEncoder(const EncoderConfig &config) {
-    switch (config.type) {
+    EncoderConfig resolved = config;
+
+    if (resolved.type == EncoderConfig::Type::Software) {
+        // Probe for NVENC — upgrade if available
+        if (avcodec_find_encoder_by_name("h264_nvenc") != nullptr) {
+            resolved.type = EncoderConfig::Type::Hardware;
+        }
+    }
+    else if (resolved.type == EncoderConfig::Type::Hardware) {
+        // Requested hardware but verify it's actually available
+        if (avcodec_find_encoder_by_name("h264_nvenc") == nullptr) {
+            resolved.type = EncoderConfig::Type::Software;
+        }
+    }
+
+    switch (resolved.type) {
     case EncoderConfig::Type::Software:
         return std::make_unique<SoftwareEncoder>();
     case EncoderConfig::Type::Hardware:


### PR DESCRIPTION
## Summary
`createEncoder()` switched directly on `config.type`, meaning NVENC was only 
used if the caller explicitly set `Type::Hardware`. On machines with a GPU, 
the pipeline defaulted to software encoding unnecessarily. On machines where 
`Type::Hardware` was set but no GPU was present, it would return an 
`NVENCEncoder` that would then fail during `initialize()` rather than 
degrading gracefully.

## Changes
- `video-core/src/encode/encoder.cpp` — `createEncoder()` now probes for 
`h264_nvenc` via `avcodec_find_encoder_by_name` before switching on 
`config.type`. Software configs are upgraded to hardware if NVENC is found; 
hardware configs are downgraded to software if NVENC is absent.

## Behavior
- Machine with NVENC: always returns `NVENCEncoder` regardless of 
`config.type`
- Machine without NVENC: always returns `SoftwareEncoder` without crashing
- Existing unit tests pass unchanged — `EncoderConfig` default type remains 
`Software`, `test_encoder_config.cpp` is unaffected

## Closes
Closes #166