### PR TITLE
fix: Add libavdevice to CMake FFmpeg dependencies

### DIFF
--- a/video-core/CMakeLists.txt
+++ b/video-core/CMakeLists.txt
@@ -16,6 +16,7 @@ pkg_check_modules(FFMPEG REQUIRED
     libavformat
     libavutil
     libswscale
+    libavdevice
 )
 
 # Compiler flags


### PR DESCRIPTION
## Summary
`camera_capture.cpp` calls `avdevice_register_all()` which lives in 
`libavdevice`, but the library was missing from the `pkg_check_modules` block 
in `video-core/CMakeLists.txt`. This caused an undefined reference error when 
building outside the dev container or on Windows. It worked in some 
environments only because another library pulled it in transitively — not a 
guarantee that can be relied on.

## Changes
- `video-core/CMakeLists.txt` — added `libavdevice` to `pkg_check_modules` 
alongside the existing FFmpeg libraries

## Closes
Closes #174