### PR TITLE
feat(infra): install External Secrets Operator via Helm in Terraform

### DIFF
--- a/infrastructure/terraform/environments/dev/.terraform.lock.hcl
+++ b/infrastructure/terraform/environments/dev/.terraform.lock.hcl
@@ -20,3 +20,43 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.13"
+  hashes = [
+    "h1:K5FEjxvDnxb1JF1kG1xr8J3pNGxoaR3Z0IBG9Csm/Is=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.30"
+  hashes = [
+    "h1:5CkveFo5ynsLdzKk+Kv+r7+U9rMrNjfZPT3a0N/fhgE=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}

--- a/infrastructure/terraform/environments/dev/main.tf
+++ b/infrastructure/terraform/environments/dev/main.tf
@@ -6,12 +6,36 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.13"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.30"
+    }
   }
 }
 
 provider "google" {
   project = var.project_id
   region  = var.region
+}
+
+data "google_client_config" "default" {}
+
+provider "kubernetes" {
+  host                   = "https://${module.gke_cluster.cluster_endpoint}"
+  token                  = data.google_client_config.default.access_token
+  cluster_ca_certificate = base64decode(module.gke_cluster.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = "https://${module.gke_cluster.cluster_endpoint}"
+    token                  = data.google_client_config.default.access_token
+    cluster_ca_certificate = base64decode(module.gke_cluster.cluster_ca_certificate)
+  }
 }
 
 module "gke_cluster" {
@@ -26,4 +50,40 @@ module "gke_cluster" {
   spot         = var.spot
   disk_size_gb = var.disk_size_gb
   network      = var.network
+}
+
+#--------------------------------
+# EXTERNAL SECRETS OPERATOR (ESO)
+#--------------------------------
+resource "kubernetes_namespace" "external_secrets" {
+  metadata {
+    name = "external-secrets"
+  }
+
+  depends_on = [module.gke_cluster]
+}
+
+import {
+  to = kubernetes_namespace.external_secrets
+  id = "external-secrets"
+}
+
+resource "helm_release" "external_secrets" {
+  name       = "external-secrets"
+  repository = "https://charts.external-secrets.io"
+  chart      = "external-secrets"
+  version    = "2.2.0"
+  namespace  = kubernetes_namespace.external_secrets.metadata[0].name
+
+  set {
+    name  = "installCRDs"
+    value = "true"
+  }
+
+  depends_on = [kubernetes_namespace.external_secrets]
+}
+
+import {
+  to = helm_release.external_secrets
+  id = "external-secrets/external-secrets"
 }

--- a/infrastructure/terraform/modules/gke-cluster/outputs.tf
+++ b/infrastructure/terraform/modules/gke-cluster/outputs.tf
@@ -9,6 +9,12 @@ output "cluster_endpoint" {
   sensitive   = true
 }
 
+output "cluster_ca_certificate" {
+  description = "Base64-encoded cluster CA certificate for authenticating to the API server"
+  value       = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+  sensitive   = true
+}
+
 output "get_credentials_command" {
   description = "gcloud command to configure kubectl"
   value       = "gcloud container clusters get-credentials ${google_container_cluster.primary.name} --zone ${var.zone} --project ${var.project_id}"


### PR DESCRIPTION
## Summary

Adds External Secrets Operator (ESO) to the dev environment via Terraform-managed Helm, so GCP Secret Manager secrets can be synced into the cluster automatically rather than created manually with `kubectl`.

- Add `hashicorp/helm` and `hashicorp/kubernetes` providers to the dev environment, authenticated via short-lived GKE access token
- Expose `cluster_ca_certificate` from the `gke-cluster` module for provider authentication
- Install ESO `2.2.0` from `charts.external-secrets.io` with CRDs enabled into the `external-secrets` namespace
- Add `import` blocks for the namespace and Helm release so `terraform apply` is idempotent on a cluster where ESO was previously installed manually
