### PR TITLE
fix: add ingress config values for local docker-compose stack

### DIFF
--- a/backend/configs/ingress.yaml
+++ b/backend/configs/ingress.yaml
@@ -1,9 +1,8 @@
 log_level: debug
 
-# Blank strings will be overridden by env vars
-api_key: ""
-api_secret: ""
-ws_url: ""
+api_key: "devkey"
+api_secret: "dev-secret-that-is-32-chars-long"
+ws_url: "ws://localhost:7880"
 
 redis:
   address: localhost:6379


### PR DESCRIPTION
## Bug — LiveKit ingress "missing API key or secret key"

**File:** `backend/configs/ingress.yaml`

### Symptom

Every WHIP connection failed immediately with:

```
ingress failed: "missing API key or secret key"
state: ENDPOINT_ERROR
```

The ingress service started and connected to Redis successfully, but every
incoming WHIP session was rejected before ICE even began.

### Root cause

`ingress.yaml` had empty `api_key` and `api_secret` fields with a comment
claiming they would be "overridden by env vars". The `docker-compose.prod.yaml`
set `LIVEKIT_API_KEY` and `LIVEKIT_API_SECRET` environment variables, but the
`livekit/ingress` Docker image does **not** map those env var names into the YAML
config fields. The ingress launched with no credentials and could not authenticate
with LiveKit when trying to publish an incoming stream.

### Fix

Set the dev credentials directly in `ingress.yaml`:

```yaml
api_key: "devkey"
api_secret: "dev-secret-that-is-32-chars-long"
ws_url: "ws://localhost:7880"
```

**Scope:** this file is only used by the local `docker-compose` stack. The
Kubernetes deployment uses `infrastructure/kubernetes/overlays/dev/patches/ingress-config.yaml`
as a ConfigMap overlay, which is mounted instead. That overlay sources its
credentials from ExternalSecrets and was already correct.