### PR TITLE
 feat(backend): add GetServerTime RPC for end-to-end latency measurement

### DIFF
--- a/backend/gen/proto/signaling/signaling.pb.go
+++ b/backend/gen/proto/signaling/signaling.pb.go
@@ -440,11 +440,11 @@ func (x *GetMySessionsReply) GetSessions() []*SessionInfo {
 // SessionInfo represents a single session in a list response
 type SessionInfo struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
-	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"` // Internal UUID, informational only
-	RoomCode      string                 `protobuf:"bytes,2,opt,name=room_code,json=roomCode,proto3" json:"room_code,omitempty"`    // Primary identifier
-	Status        string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`                        // "active" or "closed"
-	MaxCameras    int32                  `protobuf:"varint,4,opt,name=max_cameras,json=maxCameras,proto3" json:"max_cameras,omitempty"`
-	CreatedAt     string                 `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"` // RFC3339 formatted timestamp
+	SessionId     string                 `protobuf:"bytes,1,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`     // Internal UUID, informational only
+	RoomCode      string                 `protobuf:"bytes,2,opt,name=room_code,json=roomCode,proto3" json:"room_code,omitempty"`        // Primary identifier
+	Status        string                 `protobuf:"bytes,3,opt,name=status,proto3" json:"status,omitempty"`                            // "active" or "closed"
+	MaxCameras    int32                  `protobuf:"varint,4,opt,name=max_cameras,json=maxCameras,proto3" json:"max_cameras,omitempty"` // Max cameras allowed
+	CreatedAt     string                 `protobuf:"bytes,5,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`     // RFC3339 formatted timestamp
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -514,6 +514,88 @@ func (x *SessionInfo) GetCreatedAt() string {
 	return ""
 }
 
+// GetServerTimeRequest is an empty request
+type GetServerTimeRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetServerTimeRequest) Reset() {
+	*x = GetServerTimeRequest{}
+	mi := &file_signaling_proto_msgTypes[9]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetServerTimeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetServerTimeRequest) ProtoMessage() {}
+
+func (x *GetServerTimeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_signaling_proto_msgTypes[9]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetServerTimeRequest.ProtoReflect.Descriptor instead.
+func (*GetServerTimeRequest) Descriptor() ([]byte, []int) {
+	return file_signaling_proto_rawDescGZIP(), []int{9}
+}
+
+// GetServerTimeReply returns the server's current wall clock time for client clock offset calculation
+type GetServerTimeReply struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	ServerTimeNs  int64                  `protobuf:"varint,1,opt,name=server_time_ns,json=serverTimeNs,proto3" json:"server_time_ns,omitempty"` // Current server time as Unix timestamp in nanoseconds
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetServerTimeReply) Reset() {
+	*x = GetServerTimeReply{}
+	mi := &file_signaling_proto_msgTypes[10]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetServerTimeReply) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetServerTimeReply) ProtoMessage() {}
+
+func (x *GetServerTimeReply) ProtoReflect() protoreflect.Message {
+	mi := &file_signaling_proto_msgTypes[10]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetServerTimeReply.ProtoReflect.Descriptor instead.
+func (*GetServerTimeReply) Descriptor() ([]byte, []int) {
+	return file_signaling_proto_rawDescGZIP(), []int{10}
+}
+
+func (x *GetServerTimeReply) GetServerTimeNs() int64 {
+	if x != nil {
+		return x.ServerTimeNs
+	}
+	return 0
+}
+
 var File_signaling_proto protoreflect.FileDescriptor
 
 const file_signaling_proto_rawDesc = "" +
@@ -553,12 +635,16 @@ const file_signaling_proto_rawDesc = "" +
 	"\vmax_cameras\x18\x04 \x01(\x05R\n" +
 	"maxCameras\x12\x1d\n" +
 	"\n" +
-	"created_at\x18\x05 \x01(\tR\tcreatedAt2\x97\x03\n" +
+	"created_at\x18\x05 \x01(\tR\tcreatedAt\"\x16\n" +
+	"\x14GetServerTimeRequest\":\n" +
+	"\x12GetServerTimeReply\x12$\n" +
+	"\x0eserver_time_ns\x18\x01 \x01(\x03R\fserverTimeNs2\xfe\x03\n" +
 	"\x10SignalingService\x12Q\n" +
 	"\vJoinSession\x12!.directlink.signaling.JoinRequest\x1a\x1f.directlink.signaling.JoinReply\x12e\n" +
 	"\rCreateSession\x12*.directlink.signaling.CreateSessionRequest\x1a(.directlink.signaling.CreateSessionReply\x12b\n" +
 	"\fCloseSession\x12).directlink.signaling.CloseSessionRequest\x1a'.directlink.signaling.CloseSessionReply\x12e\n" +
-	"\rGetMySessions\x12*.directlink.signaling.GetMySessionsRequest\x1a(.directlink.signaling.GetMySessionsReplyB@Z>github.com/AaronBrownDev/direct-link/shared/protocol/signalingb\x06proto3"
+	"\rGetMySessions\x12*.directlink.signaling.GetMySessionsRequest\x1a(.directlink.signaling.GetMySessionsReply\x12e\n" +
+	"\rGetServerTime\x12*.directlink.signaling.GetServerTimeRequest\x1a(.directlink.signaling.GetServerTimeReplyB@Z>github.com/AaronBrownDev/direct-link/shared/protocol/signalingb\x06proto3"
 
 var (
 	file_signaling_proto_rawDescOnce sync.Once
@@ -572,7 +658,7 @@ func file_signaling_proto_rawDescGZIP() []byte {
 	return file_signaling_proto_rawDescData
 }
 
-var file_signaling_proto_msgTypes = make([]protoimpl.MessageInfo, 9)
+var file_signaling_proto_msgTypes = make([]protoimpl.MessageInfo, 11)
 var file_signaling_proto_goTypes = []any{
 	(*JoinRequest)(nil),          // 0: directlink.signaling.JoinRequest
 	(*JoinReply)(nil),            // 1: directlink.signaling.JoinReply
@@ -583,22 +669,26 @@ var file_signaling_proto_goTypes = []any{
 	(*GetMySessionsRequest)(nil), // 6: directlink.signaling.GetMySessionsRequest
 	(*GetMySessionsReply)(nil),   // 7: directlink.signaling.GetMySessionsReply
 	(*SessionInfo)(nil),          // 8: directlink.signaling.SessionInfo
+	(*GetServerTimeRequest)(nil), // 9: directlink.signaling.GetServerTimeRequest
+	(*GetServerTimeReply)(nil),   // 10: directlink.signaling.GetServerTimeReply
 }
 var file_signaling_proto_depIdxs = []int32{
-	8, // 0: directlink.signaling.GetMySessionsReply.sessions:type_name -> directlink.signaling.SessionInfo
-	0, // 1: directlink.signaling.SignalingService.JoinSession:input_type -> directlink.signaling.JoinRequest
-	2, // 2: directlink.signaling.SignalingService.CreateSession:input_type -> directlink.signaling.CreateSessionRequest
-	4, // 3: directlink.signaling.SignalingService.CloseSession:input_type -> directlink.signaling.CloseSessionRequest
-	6, // 4: directlink.signaling.SignalingService.GetMySessions:input_type -> directlink.signaling.GetMySessionsRequest
-	1, // 5: directlink.signaling.SignalingService.JoinSession:output_type -> directlink.signaling.JoinReply
-	3, // 6: directlink.signaling.SignalingService.CreateSession:output_type -> directlink.signaling.CreateSessionReply
-	5, // 7: directlink.signaling.SignalingService.CloseSession:output_type -> directlink.signaling.CloseSessionReply
-	7, // 8: directlink.signaling.SignalingService.GetMySessions:output_type -> directlink.signaling.GetMySessionsReply
-	5, // [5:9] is the sub-list for method output_type
-	1, // [1:5] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	1, // [1:1] is the sub-list for extension extendee
-	0, // [0:1] is the sub-list for field type_name
+	8,  // 0: directlink.signaling.GetMySessionsReply.sessions:type_name -> directlink.signaling.SessionInfo
+	0,  // 1: directlink.signaling.SignalingService.JoinSession:input_type -> directlink.signaling.JoinRequest
+	2,  // 2: directlink.signaling.SignalingService.CreateSession:input_type -> directlink.signaling.CreateSessionRequest
+	4,  // 3: directlink.signaling.SignalingService.CloseSession:input_type -> directlink.signaling.CloseSessionRequest
+	6,  // 4: directlink.signaling.SignalingService.GetMySessions:input_type -> directlink.signaling.GetMySessionsRequest
+	9,  // 5: directlink.signaling.SignalingService.GetServerTime:input_type -> directlink.signaling.GetServerTimeRequest
+	1,  // 6: directlink.signaling.SignalingService.JoinSession:output_type -> directlink.signaling.JoinReply
+	3,  // 7: directlink.signaling.SignalingService.CreateSession:output_type -> directlink.signaling.CreateSessionReply
+	5,  // 8: directlink.signaling.SignalingService.CloseSession:output_type -> directlink.signaling.CloseSessionReply
+	7,  // 9: directlink.signaling.SignalingService.GetMySessions:output_type -> directlink.signaling.GetMySessionsReply
+	10, // 10: directlink.signaling.SignalingService.GetServerTime:output_type -> directlink.signaling.GetServerTimeReply
+	6,  // [6:11] is the sub-list for method output_type
+	1,  // [1:6] is the sub-list for method input_type
+	1,  // [1:1] is the sub-list for extension type_name
+	1,  // [1:1] is the sub-list for extension extendee
+	0,  // [0:1] is the sub-list for field type_name
 }
 
 func init() { file_signaling_proto_init() }
@@ -612,7 +702,7 @@ func file_signaling_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_signaling_proto_rawDesc), len(file_signaling_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   9,
+			NumMessages:   11,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/backend/gen/proto/signaling/signaling_grpc.pb.go
+++ b/backend/gen/proto/signaling/signaling_grpc.pb.go
@@ -23,6 +23,7 @@ const (
 	SignalingService_CreateSession_FullMethodName = "/directlink.signaling.SignalingService/CreateSession"
 	SignalingService_CloseSession_FullMethodName  = "/directlink.signaling.SignalingService/CloseSession"
 	SignalingService_GetMySessions_FullMethodName = "/directlink.signaling.SignalingService/GetMySessions"
+	SignalingService_GetServerTime_FullMethodName = "/directlink.signaling.SignalingService/GetServerTime"
 )
 
 // SignalingServiceClient is the client API for SignalingService service.
@@ -39,6 +40,8 @@ type SignalingServiceClient interface {
 	CloseSession(ctx context.Context, in *CloseSessionRequest, opts ...grpc.CallOption) (*CloseSessionReply, error)
 	// GetMySessions returns all sessions creates by the requesting user
 	GetMySessions(ctx context.Context, in *GetMySessionsRequest, opts ...grpc.CallOption) (*GetMySessionsReply, error)
+	// GetServerTime returns the server time in nanoseconds
+	GetServerTime(ctx context.Context, in *GetServerTimeRequest, opts ...grpc.CallOption) (*GetServerTimeReply, error)
 }
 
 type signalingServiceClient struct {
@@ -89,6 +92,16 @@ func (c *signalingServiceClient) GetMySessions(ctx context.Context, in *GetMySes
 	return out, nil
 }
 
+func (c *signalingServiceClient) GetServerTime(ctx context.Context, in *GetServerTimeRequest, opts ...grpc.CallOption) (*GetServerTimeReply, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(GetServerTimeReply)
+	err := c.cc.Invoke(ctx, SignalingService_GetServerTime_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SignalingServiceServer is the server API for SignalingService service.
 // All implementations must embed UnimplementedSignalingServiceServer
 // for forward compatibility.
@@ -103,6 +116,8 @@ type SignalingServiceServer interface {
 	CloseSession(context.Context, *CloseSessionRequest) (*CloseSessionReply, error)
 	// GetMySessions returns all sessions creates by the requesting user
 	GetMySessions(context.Context, *GetMySessionsRequest) (*GetMySessionsReply, error)
+	// GetServerTime returns the server time in nanoseconds
+	GetServerTime(context.Context, *GetServerTimeRequest) (*GetServerTimeReply, error)
 	mustEmbedUnimplementedSignalingServiceServer()
 }
 
@@ -124,6 +139,9 @@ func (UnimplementedSignalingServiceServer) CloseSession(context.Context, *CloseS
 }
 func (UnimplementedSignalingServiceServer) GetMySessions(context.Context, *GetMySessionsRequest) (*GetMySessionsReply, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetMySessions not implemented")
+}
+func (UnimplementedSignalingServiceServer) GetServerTime(context.Context, *GetServerTimeRequest) (*GetServerTimeReply, error) {
+	return nil, status.Error(codes.Unimplemented, "method GetServerTime not implemented")
 }
 func (UnimplementedSignalingServiceServer) mustEmbedUnimplementedSignalingServiceServer() {}
 func (UnimplementedSignalingServiceServer) testEmbeddedByValue()                          {}
@@ -218,6 +236,24 @@ func _SignalingService_GetMySessions_Handler(srv interface{}, ctx context.Contex
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SignalingService_GetServerTime_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(GetServerTimeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SignalingServiceServer).GetServerTime(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SignalingService_GetServerTime_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SignalingServiceServer).GetServerTime(ctx, req.(*GetServerTimeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SignalingService_ServiceDesc is the grpc.ServiceDesc for SignalingService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -240,6 +276,10 @@ var SignalingService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "GetMySessions",
 			Handler:    _SignalingService_GetMySessions_Handler,
+		},
+		{
+			MethodName: "GetServerTime",
+			Handler:    _SignalingService_GetServerTime_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/backend/internal/signaling/grpc.go
+++ b/backend/internal/signaling/grpc.go
@@ -251,7 +251,7 @@ func (s *Server) GetMySessions(ctx context.Context, req *pb.GetMySessionsRequest
 }
 
 // GetServerTime returns the server time in unix nanoseconds
-func (s *Server) GetServerTime(ctx context.Context, _ *pb.GetServerTimeRequest) (*pb.GetServerTimeReply, error) {
+func (s *Server) GetServerTime(_ context.Context, _ *pb.GetServerTimeRequest) (*pb.GetServerTimeReply, error) {
 	s.metrics.LatencyRequestsTotal.Inc()
 	return &pb.GetServerTimeReply{
 		ServerTimeNs: time.Now().UnixNano(),

--- a/backend/internal/signaling/grpc.go
+++ b/backend/internal/signaling/grpc.go
@@ -249,3 +249,11 @@ func (s *Server) GetMySessions(ctx context.Context, req *pb.GetMySessionsRequest
 	}
 	return &pb.GetMySessionsReply{Sessions: pbSessions}, nil
 }
+
+// GetServerTime returns the server time in unix nanoseconds
+func (s *Server) GetServerTime(ctx context.Context, _ *pb.GetServerTimeRequest) (*pb.GetServerTimeReply, error) {
+	s.metrics.LatencyRequestsTotal.Inc()
+	return &pb.GetServerTimeReply{
+		ServerTimeNs: time.Now().UnixNano(),
+	}, nil
+}

--- a/backend/internal/signaling/grpc_test.go
+++ b/backend/internal/signaling/grpc_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/AaronBrownDev/direct-link/pkg/session"
 	"github.com/alicebob/miniredis/v2"
 	"github.com/livekit/protocol/livekit"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 )
 
 // --- Stub Store ---
@@ -318,6 +319,65 @@ func TestJoinSession_CameraRole_RollsBackIngressOnGrantAccessFailure(t *testing.
 	// The ingress should have been rolled back via DeleteIngress
 	if len(mockIngress.deletedIDs) != 1 || mockIngress.deletedIDs[0] != "ingress-abc" {
 		t.Errorf("expected ingress-abc to be rolled back, got deletedIDs=%v", mockIngress.deletedIDs)
+	}
+}
+
+// --- GetServerTime tests ---
+
+func TestGetServerTime(t *testing.T) {
+	tests := []struct {
+		name      string
+		callCount int
+	}{
+		{
+			name:      "returns non-zero timestamp",
+			callCount: 1,
+		},
+		{
+			name:      "timestamp within 1ms of call time",
+			callCount: 1,
+		},
+		{
+			name:      "increments counter on each call",
+			callCount: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := newUnitTestServer(t, defaultMockIngress(), defaultMockRoom())
+
+			var reply *pb.GetServerTimeReply
+			var err error
+			before := time.Now()
+			for range tt.callCount {
+				reply, err = srv.GetServerTime(context.Background(), &pb.GetServerTimeRequest{})
+			}
+			after := time.Now()
+
+			if err != nil {
+				t.Fatalf("GetServerTime() unexpected error: %v", err)
+			}
+			if reply == nil {
+				t.Fatal("GetServerTime() returned nil reply")
+			}
+
+			gotNs := reply.ServerTimeNs
+			if gotNs == 0 {
+				t.Error("ServerTimeNs is zero, expected a real Unix timestamp")
+			}
+
+			const toleranceNs = int64(time.Millisecond)
+			if gotNs < before.UnixNano()-toleranceNs || gotNs > after.UnixNano()+toleranceNs {
+				t.Errorf("ServerTimeNs %d is outside [%d, %d] (±1ms window around call)",
+					gotNs, before.UnixNano(), after.UnixNano())
+			}
+
+			got := testutil.ToFloat64(srv.metrics.LatencyRequestsTotal)
+			if got != float64(tt.callCount) {
+				t.Errorf("latency_time_requests_total = %f, want %f", got, float64(tt.callCount))
+			}
+		})
 	}
 }
 

--- a/backend/pkg/metrics/metrics.go
+++ b/backend/pkg/metrics/metrics.go
@@ -18,6 +18,7 @@ type Metrics struct {
 	SessionsCreatedTotal  prometheus.Counter
 	SessionsExpiredTotal  prometheus.Counter
 	TokenGenerationsTotal *prometheus.CounterVec
+	LatencyRequestsTotal  prometheus.Counter
 
 	// Redis metrics
 	RedisOperationDuration *prometheus.HistogramVec
@@ -59,6 +60,12 @@ func New() *Metrics {
 			[]string{"role"}, // "camera" or "director"
 		),
 
+		LatencyRequestsTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "directlink",
+			Name:      "latency_time_requests_total",
+			Help:      "Total number of GetServerTime RPC calls received.",
+		}),
+
 		RedisOperationDuration: prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: "directlink",
@@ -90,6 +97,7 @@ func New() *Metrics {
 		m.SessionsActive,
 		m.SessionsCreatedTotal,
 		m.TokenGenerationsTotal,
+		m.LatencyRequestsTotal,
 		m.RedisOperationDuration,
 		m.RedisErrorsTotal,
 	)

--- a/backend/pkg/metrics/metrics_test.go
+++ b/backend/pkg/metrics/metrics_test.go
@@ -171,6 +171,45 @@ func TestMetrics_TokenGenerationsTotal(t *testing.T) {
 	}
 }
 
+func TestMetrics_LatencyRequestsTotal(t *testing.T) {
+	tests := []struct {
+		name     string
+		incCount int
+		expected float64
+	}{
+		{
+			name:     "starts at zero",
+			incCount: 0,
+			expected: 0,
+		},
+		{
+			name:     "single request",
+			incCount: 1,
+			expected: 1,
+		},
+		{
+			name:     "multiple requests",
+			incCount: 5,
+			expected: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := metrics.New()
+
+			for range tt.incCount {
+				m.LatencyRequestsTotal.Inc()
+			}
+
+			got := testutil.ToFloat64(m.LatencyRequestsTotal)
+			if got != tt.expected {
+				t.Errorf("latency_time_requests_total = %f, want %f", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestMetrics_RedisErrorsTotal(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -239,6 +278,7 @@ func TestMetrics_RegistryContainsAllMetrics(t *testing.T) {
 		{"sessions active gauge", "directlink_sessions_active"},
 		{"sessions created counter", "directlink_sessions_created_total"},
 		{"token generations counter vec", "directlink_token_generations_total"},
+		{"latency requests counter", "directlink_latency_time_requests_total"},
 		{"redis operation duration histogram", "directlink_redis_operation_duration_seconds"},
 		{"redis errors counter vec", "directlink_redis_errors_total"},
 		{"go goroutines collector", "go_goroutines"},

--- a/docs/api/client_grpc_guide.md
+++ b/docs/api/client_grpc_guide.md
@@ -146,6 +146,45 @@ This section documents the endpoints that will be used by the client to `Create 
     - **Camera operators can rejoin after disconnecting** by calling JoinSession again with the same room code. They do not need a new room code from the director.
     - **Director tokens expire after 1 hour.** If the director's LiveKit connection drops due to token expiry, call JoinSession again to get a fresh token.
 
+- **GetServerTime**
+    1. **Purpose**: Returns the server's current wall-clock time in nanoseconds. Both camera and director machines call this independently to compute their clock offset relative to the server, putting their timestamps in a shared reference frame so end-to-end latency can be measured across machines with independent clocks.
+    2. **Who calls it**: Camera operators and directors — any client that needs to correct its local timestamps.
+    3. **Request fields**: None.
+    4. **Response fields**:
+        - **server_time_ns (int64)**: Current server time as a Unix timestamp in nanoseconds.
+    5. **All possible errors**: This endpoint is unauthenticated and has no required fields. No application-level errors are expected; treat any `Internal` response as transient and retry.
+    6. **An example**:
+    ```
+    - Request: (empty)
+    - Response:
+        "server_time_ns": 1743628800000000000
+    ```
+
+    **Clock Offset Formula (required for end-to-end latency measurement)**:
+
+    ```
+    t1            = client time immediately before sending the request (nanoseconds)
+    t2            = client time immediately after receiving the response (nanoseconds)
+    server_time   = server_time_ns from the response
+
+    clock_offset  = server_time - (t1 + t2) / 2
+
+    corrected_timestamp = local_time + clock_offset
+    ```
+
+    The `(t1 + t2) / 2` midpoint is the client's best estimate of the moment the server recorded its timestamp, assuming equal one-way delays. Network delay is not subtracted — it is absorbed into the midpoint calculation (same approach used by NTP).
+
+    Clients should call `GetServerTime` on a regular interval (e.g. every 5 seconds) and apply a rolling average over recent samples to smooth out jitter. Do not use a single sample.
+
+    **Accuracy note**: The residual error comes from network asymmetry — if the request and response take different amounts of time, the midpoint estimate is off by half the difference. On our GKE dev cluster this asymmetry is typically sub-millisecond, well within the sub-150ms latency target.
+
+    **End-to-end latency pipeline (camera + director coordination required)**:
+
+    - **Camera side**: embed `corrected_stamp = now() + offset_cam` into each frame as an RTP header extension before it enters the GStreamer WHIP pipeline.
+    - **Director side**: extract that RTP header extension timestamp on receipt, then compute `e2e_latency = (now() + offset_dir) - corrected_stamp`.
+
+    The specific RTP header extension ID and format must be agreed on between the camera and director implementations before merging.
+
 
 ## *Data Models*
 
@@ -322,6 +361,24 @@ Expected response:
       "status": "closed"
     }
   ]
+}
+```
+
+### GetServerTime
+
+Record `t1` immediately before the call and `t2` immediately after. The clock offset is `server_time_ns - (t1 + t2) / 2`.
+
+```bash
+grpcurl -plaintext \
+  dev:50051 \
+  directlink.signaling.SignalingService/GetServerTime
+```
+
+Expected response:
+
+```json
+{
+  "serverTimeNs": 1743628800000000000
 }
 ```
 

--- a/shared/protocol/signaling.proto
+++ b/shared/protocol/signaling.proto
@@ -15,7 +15,8 @@ service SignalingService {
     rpc CloseSession(CloseSessionRequest) returns (CloseSessionReply);
     // GetMySessions returns all sessions creates by the requesting user
     rpc GetMySessions(GetMySessionsRequest) returns (GetMySessionsReply);
-
+    // GetServerTime returns the server time in nanoseconds
+    rpc GetServerTime(GetServerTimeRequest) returns (GetServerTimeReply);
 }
 
 // JoinRequest initiates joining a session
@@ -70,6 +71,14 @@ message SessionInfo{
     string session_id = 1; // Internal UUID, informational only
     string room_code = 2; // Primary identifier
     string status = 3; // "active" or "closed"
-    int32 max_cameras = 4;
+    int32 max_cameras = 4; // Max cameras allowed
     string created_at = 5; // RFC3339 formatted timestamp
+}
+
+// GetServerTimeRequest is an empty request
+message GetServerTimeRequest {}
+
+// GetServerTimeReply returns the server's current wall clock time for client clock offset calculation 
+message GetServerTimeReply {
+    int64 server_time_ns = 1; // Current server time as Unix timestamp in nanoseconds
 }


### PR DESCRIPTION
## Summary

Adds a `GetServerTime` RPC to the signaling server so camera and director machines can independently compute their clock offset relative to a shared time reference. Once both sides correct their local timestamps into server time, end-to-end latency can be measured by simple subtraction across machines with independent clocks.

Closes #201

## Changes

### `shared/protocol/signaling.proto`
- Add `GetServerTime` RPC to `SignalingService`
- Add empty `GetServerTimeRequest` and `GetServerTimeReply` messages (`server_time_ns int64`)

### `gen/proto/signaling/`
- Regenerated `signaling.pb.go` and `signaling_grpc.pb.go` to include the new RPC

### `backend/pkg/metrics/metrics.go`
- Add `LatencyRequestsTotal` counter (`directlink_latency_time_requests_total`)

### `backend/internal/signaling/grpc.go`
- Implement `GetServerTime`: returns `time.Now().UnixNano()` and increments the counter

### `backend/internal/signaling/grpc_test.go`
- Add `TestGetServerTime` covering: non-zero timestamp, ±1ms window around call time, and per-call counter increments

### `backend/pkg/metrics/metrics_test.go`
- Add `TestMetrics_LatencyRequestsTotal` covering zero, single, and multiple increments

### `docs/api/client_grpc_guide.md`
- Document `GetServerTime` endpoint spec, clock offset formula, symmetric delay accuracy tradeoff, and RTP header extension requirements for the full latency pipeline

## Notes

- Decided to implement as a gRPC RPC on the existing `50051` port rather than a separate HTTP endpoint. No Kubernetes service changes required.
- The full latency pipeline requires coordination with the camera side (embed corrected timestamp as RTP header extension) and director side (extract and subtract). That work is out of scope for this PR.