### PR TITLE
fix(client): migrate whip publisher client fixes

### DIFF
--- a/backend/configs/ingress.yaml
+++ b/backend/configs/ingress.yaml
@@ -1,5 +1,6 @@
 log_level: debug
 
+# Set dev credentials directly for docker-compose - LiveKit/Ingress fails to set credentials automatically
 api_key: "devkey"
 api_secret: "dev-secret-that-is-32-chars-long"
 ws_url: "ws://localhost:7880"

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -12,7 +12,28 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Qt6 REQUIRED COMPONENTS  Core Quick QuickControls2 Multimedia Concurrent Protobuf Grpc)
 find_package(PkgConfig REQUIRED)
-find_package(Microsoft.GSL CONFIG REQUIRED)
+find_package(Microsoft.GSL CONFIG)
+find_package(fmt CONFIG)
+if(NOT fmt_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        fmt
+        URL https://github.com/fmtlib/fmt/archive/refs/tags/11.1.4.tar.gz
+        URL_HASH SHA256=b888d55b0caf8f2f213a94f2b7d58bf2e2630ff0b0c87f8c5c74e2ab1b770289
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(fmt)
+endif()
+if(NOT Microsoft.GSL_FOUND)
+    include(FetchContent)
+    FetchContent_Declare(
+        microsoft_gsl
+        URL https://github.com/microsoft/GSL/archive/refs/tags/v4.2.0.tar.gz
+        URL_HASH SHA256=2c717545a073649126cb99ebd493fa2ae23120077968795d2c69cbab821e4ac6
+        DOWNLOAD_EXTRACT_TIMESTAMP TRUE
+    )
+    FetchContent_MakeAvailable(microsoft_gsl)
+endif()
 pkg_check_modules(FFMPEG REQUIRED
     libavcodec
     libavutil
@@ -67,8 +88,8 @@ qt_add_grpc(signaling_grpc CLIENT
 
 target_link_libraries(signaling_grpc PRIVATE signaling_proto)
 
-# LiveKit SDK (pre-built in container)
-set(LIVEKIT_DIR /home/vscode/livekit-cpp)
+# LiveKit SDK — can be overriden with -DLIVEKIT_DIR=<path> at configure time
+set(LIVEKIT_DIR "/home/vscode/livekit-cpp" CACHE PATH "Path to livekit-cpp SDK directory")
 
 add_library(livekit SHARED IMPORTED)
 set_target_properties(livekit PROPERTIES
@@ -123,6 +144,7 @@ target_link_libraries(direct-link PRIVATE
     signaling_grpc
     livekit
     livekit_ffi
+    fmt
     directlink_appplugin
     directlink_uiplugin
     directlink_ui_controlsplugin

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -65,6 +65,10 @@ qt_add_executable(test_livekit_room
     tests/test_livekit_room.cpp
 )
 
+qt_add_executable(test_operator_session
+    tests/test_operator_session.cpp
+)
+
 # QTP0001: Changes default RESOURCE_PREFIX for qt_add_qml_module from "/"
 # to "qt/qml/". Removes the need to call addImportPath manually.
 qt_policy(SET QTP0001 NEW)
@@ -131,6 +135,18 @@ target_include_directories(test_livekit_room PRIVATE
     ${CMAKE_BINARY_DIR}
 )
 
+target_include_directories(test_operator_session PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/network
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/session
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${LIVEKIT_DIR}/include
+    ${CMAKE_BINARY_DIR}
+    ${GST_INCLUDE_DIRS}
+    ${FFMPEG_LIBRARIES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../video-core/include
+)
+
 target_link_libraries(direct-link PRIVATE
     Qt6::Core
     Qt6::Quick
@@ -177,6 +193,23 @@ target_link_libraries(test_livekit_room PRIVATE
     livekit_ffi
     directlink_networkplugin
     directlink_appplugin
+    video_core
+)
+
+target_link_libraries(test_operator_session PRIVATE
+    Qt6::Core
+    Qt6::Quick
+    Qt6::Multimedia
+    Qt6::Concurrent
+    Qt6::Protobuf
+    Qt6::Grpc
+    signaling_proto
+    signaling_grpc
+    livekit
+    livekit_ffi
+    directlink_appplugin
+    directlink_networkplugin
+    directlink_sessionplugin
     video_core
 )
 

--- a/client/src/application/Main.qml
+++ b/client/src/application/Main.qml
@@ -26,7 +26,7 @@ Window {
     property string user_id: ""
     property int user_type: UserRole.director
 
-    property url channel: "http://localhost:50051"
+    property url channel: "http://34.174.71.83:50051"
     property bool connected: false
 
     property string last_room: ""

--- a/client/src/application/views/SessionDirectorView.qml
+++ b/client/src/application/views/SessionDirectorView.qml
@@ -45,7 +45,7 @@ RowLayout {
             Layout.preferredHeight: width / aspect_ratio
             Layout.minimumHeight: implicitWidth / aspect_ratio
             
-            Layout.maximumWidth: dl_operator_view.height * aspect_ratio
+            Layout.maximumWidth: dl_director_view.height * aspect_ratio
             implicitWidth: 500
         }
 

--- a/client/src/application/views/SessionOperatorView.qml
+++ b/client/src/application/views/SessionOperatorView.qml
@@ -8,13 +8,21 @@
 
 import QtQuick
 import QtQuick.Layouts
-import QtMultimedia
+import session
 import ui.controls
 
 RowLayout {
         id: dl_operator_view
 
         spacing: 15
+
+        Component.onCompleted: {
+            CameraSessionController.previewSink = dl_camera_preview.video_sink;
+        }
+
+        Component.onDestruction: {
+            CameraSessionController.previewSink = null;
+        }
 
         SessionLog {
             id: dl_session_log
@@ -29,14 +37,5 @@ RowLayout {
             Layout.minimumHeight: implicitWidth / aspect_ratio
             Layout.maximumWidth: dl_operator_view.height * aspect_ratio
             implicitWidth: 500
-        }
-
-        CaptureSession {
-            id: dl_capture_session
-            camera: Camera {
-                id: dl_camera
-                active: true
-            }
-            videoOutput: dl_camera_preview.video_sink
         }
     }

--- a/client/src/framereader.cpp
+++ b/client/src/framereader.cpp
@@ -54,13 +54,13 @@ void FrameReader::pushFrame(livekit::VideoFrame frame) {
     const uint8_t *src = frame.data();
     const std::size_t size = frame.dataSize();
 
-    if ((src == nullptr) || size == 0) {
+    if (src == nullptr || size == 0) {
         qWarning() << "[FrameReader] Received empty frame. Pushing placeholder frame.";
         pushFrame();
         return;
     }
 
-    QSize dimensions(static_cast<int>(frame.width()), static_cast<int>(frame.height()));
+    QSize dimensions(frame.width(), frame.height());
 
     if (dimensions.isEmpty()) {
         qWarning() << "[FrameReader] Frame has no dimensions. Pushing placeholder frame.";
@@ -68,7 +68,87 @@ void FrameReader::pushFrame(livekit::VideoFrame frame) {
         return;
     }
     
-    std::span<const uint8_t> data(src, size);
+    // I420 is the native H.264 decoder output. Deliver directly to Qt as
+    // YUV420P via planeInfos() for correct plane pointers/strides.
+    if (frame.type() == livekit::VideoBufferType::I420) {
+        if (m_videoSink == nullptr) {
+            qWarning() << "[FrameReader] Video sink not set. Skipping frame.";
+            return;
+        }
+
+        const int w = frame.width();
+        const int h = frame.height();
+
+        auto planes = frame.planeInfos();
+        if (planes.size() < 3) {
+            qWarning() << "[FrameReader] I420 frame has" << planes.size()
+                       << "planes, expected 3. Falling back to SDK convert.";
+            // Fall through to the SDK RGBA conversion path below.
+        } else {
+            const auto *y_plane = reinterpret_cast<const uint8_t *>(planes[0].data_ptr);
+            const auto *u_plane = reinterpret_cast<const uint8_t *>(planes[1].data_ptr);
+            const auto *v_plane = reinterpret_cast<const uint8_t *>(planes[2].data_ptr);
+            const int y_stride = static_cast<int>(planes[0].stride);
+            const int u_stride = static_cast<int>(planes[1].stride);
+            const int v_stride = static_cast<int>(planes[2].stride);
+
+            QVideoFrameFormat fmt(QSize(w, h), QVideoFrameFormat::Format_YUV420P);
+            QVideoFrame vf(fmt);
+
+            if (!vf.map(QVideoFrame::WriteOnly)) {
+                qWarning() << "[FrameReader] Failed to map YUV420P frame.";
+                return;
+            }
+
+            // Copy Y plane
+            const int dst_y_stride = vf.bytesPerLine(0);
+            auto *dst_y = vf.bits(0);
+            for (int row = 0; row < h; ++row) {
+                std::memcpy(dst_y + row * dst_y_stride,
+                            y_plane + row * y_stride,
+                            static_cast<size_t>(w));
+            }
+
+            // Copy U plane
+            const int dst_u_stride = vf.bytesPerLine(1);
+            auto *dst_u = vf.bits(1);
+            for (int row = 0; row < h / 2; ++row) {
+                std::memcpy(dst_u + row * dst_u_stride,
+                            u_plane + row * u_stride,
+                            static_cast<size_t>(w / 2));
+            }
+
+            // Copy V plane
+            const int dst_v_stride = vf.bytesPerLine(2);
+            auto *dst_v = vf.bits(2);
+            for (int row = 0; row < h / 2; ++row) {
+                std::memcpy(dst_v + row * dst_v_stride,
+                            v_plane + row * v_stride,
+                            static_cast<size_t>(w / 2));
+            }
+
+            vf.unmap();
+            m_videoSink->setVideoFrame(vf);
+            return;
+        }
+    }
+
+    // Fallback: convert to RGBA and push as RGBA8888.
+    if (frame.type() != livekit::VideoBufferType::RGBA) {
+        qWarning() << "[FrameReader] Unexpected frame type"
+                   << static_cast<int>(frame.type()) << ". Converting to RGBA.";
+        try {
+            frame = frame.convert(livekit::VideoBufferType::RGBA);
+        } catch (const std::exception &e) {
+            qWarning() << "[FrameReader] Frame conversion to RGBA failed:" << e.what()
+                       << ". Pushing placeholder frame.";
+            pushFrame();
+            return;
+        }
+    }
+
+    std::span<const uint8_t> data(frame.data(), frame.dataSize());
+    
     bool success = pushSpan(data, dimensions, QVideoFrameFormat::Format_RGBA8888);
 
     if (!success) {

--- a/client/src/session/CMakeLists.txt
+++ b/client/src/session/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(directlink_session PRIVATE
     Qt6::Core
     Qt6::Qml
     Qt6::Concurrent
+    Qt6::Multimedia
     video_core
     directlink_networking
 )

--- a/client/src/session/camera_session.cpp
+++ b/client/src/session/camera_session.cpp
@@ -51,10 +51,9 @@ bool CameraSession::start(const std::string &whipUrl,
         return false;
     }
 
-    // TODO: Add setKeyFrameRequestCallback to WHIP Publisher
-    //  whipPublisher_.setKeyframeRequestCallback([this]() {
-    //     pipeline_.requestKeyframe();
-    // });
+     whipPublisher_.setKeyframeRequestCallback([this]() {
+        pipeline_.requestKeyframe();
+    });
 
     // The WHIP publisher is started first to set running_ to true 
     // before producing frames to avoid dropping frames during

--- a/client/src/session/camera_session.cpp
+++ b/client/src/session/camera_session.cpp
@@ -15,8 +15,7 @@ bool CameraSession::start(const std::string &whipUrl,
     #else
         captureConfig.devicePath = "/dev/video0";
         captureConfig.inputFormat = "v4l2";
-        // TODO: Add pixel_format to videoCore::capture::captureConfig
-        // captureConfig.pixelFormat = "mjpeg";
+        captureConfig.pixelFormat = "mjpeg";
     #endif
     captureConfig.width = 1280;
     captureConfig.height = 720;
@@ -35,8 +34,7 @@ bool CameraSession::start(const std::string &whipUrl,
                   << videoCore::resultToString(startResult)
                   << " (device=" << captureConfig.devicePath
                   << ", format=" << captureConfig.inputFormat
-                //   TODO: Add pixel_format to videoCore::capture::captureConfig
-                //   << ", pixel_format=" << captureConfig.pixelFormat
+                  << ", pixel_format=" << captureConfig.pixelFormat
                   << ", " << captureConfig.width << "x" << captureConfig.height
                   << "@" << captureConfig.framerate << "fps)\n";
         return false; // Failed to initialize pipeline

--- a/client/src/session/camera_session.cpp
+++ b/client/src/session/camera_session.cpp
@@ -1,4 +1,5 @@
 #include "camera_session.hpp"
+#include "../../../video-core/include/common/types.hpp"
 #include <iostream>
 
 bool CameraSession::start(const std::string &whipUrl,
@@ -14,37 +15,55 @@ bool CameraSession::start(const std::string &whipUrl,
     #else
         captureConfig.devicePath = "/dev/video0";
         captureConfig.inputFormat = "v4l2";
+        // TODO: Add pixel_format to videoCore::capture::captureConfig
+        // captureConfig.pixelFormat = "mjpeg";
     #endif
-    captureConfig.width = 640;
-    captureConfig.height = 480;
-    captureConfig.framerate = 5;
+    captureConfig.width = 1280;
+    captureConfig.height = 720;
+    captureConfig.framerate = 30;
 
     videoCore::encode::EncoderConfig encoderConfig;
-    encoderConfig.width = 1920;
-    encoderConfig.height = 1080;
-    encoderConfig.framerate = 30;
+    encoderConfig.width = captureConfig.width;
+    encoderConfig.height = captureConfig.height;
+    encoderConfig.framerate = captureConfig.framerate;
     encoderConfig.bitrate = 4000000;
     encoderConfig.preset = videoCore::encode::EncoderConfig::Preset::UltraFast;
 
     auto startResult = pipeline_.initialize(captureConfig, encoderConfig);
     if (startResult != videoCore::Result::Success) {
+        std::cerr << "[CameraSession] Failed to initialize video pipeline: "
+                  << videoCore::resultToString(startResult)
+                  << " (device=" << captureConfig.devicePath
+                  << ", format=" << captureConfig.inputFormat
+                //   TODO: Add pixel_format to videoCore::capture::captureConfig
+                //   << ", pixel_format=" << captureConfig.pixelFormat
+                  << ", " << captureConfig.width << "x" << captureConfig.height
+                  << "@" << captureConfig.framerate << "fps)\n";
         return false; // Failed to initialize pipeline
     }
     
     auto whipPublisherResult = whipPublisher_.initialize(
         whipUrl, streamKey, encoderConfig.framerate,
         [](const std::string &err) {
-            std::cerr << "WHIPPublisher error: " << err << "\n";
+            std::cerr << "[CameraSession] WHIPPublisher error: " << err << "\n";
         });
     if (whipPublisherResult != networking::Result::Success) {
-        return false; // Failed to initialize WHIP publisher
+        std::cerr << "[CameraSession] Failed to initialize WHIP publisher"
+                     " (url=" << whipUrl << ")\n";
+        return false;
     }
+
+    // TODO: Add setKeyFrameRequestCallback to WHIP Publisher
+    //  whipPublisher_.setKeyframeRequestCallback([this]() {
+    //     pipeline_.requestKeyframe();
+    // });
 
     // The WHIP publisher is started first to set running_ to true 
     // before producing frames to avoid dropping frames during
     // publisher startup.
     auto publisherResult = whipPublisher_.start();
     if (publisherResult != networking::Result::Success) {
+        std::cerr << "[CameraSession] Failed to start WHIP publisher"
         pipeline_.stop();
         return false;
     }
@@ -55,21 +74,30 @@ bool CameraSession::start(const std::string &whipUrl,
         });
 
     if (pipelineResult != videoCore::Result::Success) {
+        std::cerr << "[CameraSession] Failed to start video pipeline: "
+                  << videoCore::resultToString(pipelineResult) << "\n";
         whipPublisher_.stop();
         return false;
     }
 
-    
-
     isRunning_ = true;
     return true;
+}
+
+// TODO: Add setPreviewCallback method to videoCore::pipeline::VideoPipeline
+void CameraSession::setPreviewCallback(std::function<void(const videoCore::Frame &)> cb) {
+    // pipeline_.setPreviewCallback(std::move(cb));
 }
 
 void CameraSession::stop() {
     if (!isRunning_) {
         return; // Not running
     }
-    pipeline_.stop();
+    const auto stop_result = pipeline_.stop();
+    if (stop_result != videoCore::Result::Success) {
+        std::cerr << "[CameraSession] Pipeline stop returned an error: "
+                  << videoCore::resultToString(stop_result) << "\n";
+    }
     whipPublisher_.stop();
     isRunning_ = false;
 }

--- a/client/src/session/camera_session.cpp
+++ b/client/src/session/camera_session.cpp
@@ -61,7 +61,7 @@ bool CameraSession::start(const std::string &whipUrl,
     // publisher startup.
     auto publisherResult = whipPublisher_.start();
     if (publisherResult != networking::Result::Success) {
-        std::cerr << "[CameraSession] Failed to start WHIP publisher"
+        std::cerr << "[CameraSession] Failed to start WHIP publisher";
         pipeline_.stop();
         return false;
     }
@@ -82,9 +82,8 @@ bool CameraSession::start(const std::string &whipUrl,
     return true;
 }
 
-// TODO: Add setPreviewCallback method to videoCore::pipeline::VideoPipeline
 void CameraSession::setPreviewCallback(std::function<void(const videoCore::Frame &)> cb) {
-    // pipeline_.setPreviewCallback(std::move(cb));
+    pipeline_.setPreviewCallback(std::move(cb));
 }
 
 void CameraSession::stop() {

--- a/client/src/session/camera_session.cpp
+++ b/client/src/session/camera_session.cpp
@@ -40,6 +40,15 @@ bool CameraSession::start(const std::string &whipUrl,
         return false; // Failed to initialize WHIP publisher
     }
 
+    // The WHIP publisher is started first to set running_ to true 
+    // before producing frames to avoid dropping frames during
+    // publisher startup.
+    auto publisherResult = whipPublisher_.start();
+    if (publisherResult != networking::Result::Success) {
+        pipeline_.stop();
+        return false;
+    }
+
     auto pipelineResult =
         pipeline_.start([this](std::unique_ptr<videoCore::Packet> pkt) {
             whipPublisher_.pushPacket(std::move(pkt));
@@ -50,11 +59,7 @@ bool CameraSession::start(const std::string &whipUrl,
         return false;
     }
 
-    auto publisherResult = whipPublisher_.start();
-    if (publisherResult != networking::Result::Success) {
-        pipeline_.stop();
-        return false;
-    }
+    
 
     isRunning_ = true;
     return true;

--- a/client/src/session/camera_session.hpp
+++ b/client/src/session/camera_session.hpp
@@ -15,6 +15,7 @@ public:
 
     bool start(const std::string &whipUrl, const std::string &streamKey);
     void stop();
+    void setPreviewCallback(std::function<void(const videoCore::Frame &)> cb);
 
 private:
     videoCore::pipeline::VideoPipeline pipeline_;

--- a/client/src/session/session_controller.cpp
+++ b/client/src/session/session_controller.cpp
@@ -1,33 +1,69 @@
 #include "session_controller.hpp"
 
 #include <QDebug>
+#include <QVideoFrame>
+#include <QVideoFrameFormat>
+#include <QVideoSink>
 #include <QtConcurrent/QtConcurrent>
+#include <cstring>
 
 CameraSessionController::CameraSessionController(QObject *parent)
     : QObject(parent)
     , session_(std::make_shared<CameraSession>()) {}
 
 CameraSessionController::~CameraSessionController() {
-    if (m_startFuture.isRunning()) {
-        m_startFuture.waitForFinished();
+    if (startFuture_.isRunning()) {
+        startFuture_.waitForFinished();
     }
 }
 
 void CameraSessionController::start(const QString &whipUrl,
                                      const QString &streamKey) {
-    if ((m_startWatcher != nullptr) && m_startWatcher->isRunning()) {
+    if ((startWatcher_ != nullptr) && startWatcher_->isRunning()) {
         return;
     }
 
     std::string std_url = whipUrl.toStdString();
     std::string std_key = streamKey.toStdString();
 
-    m_startWatcher = new QFutureWatcher<bool>(this);
+    // Wire up preview callback
+    if (previewSink_ != nullptr) {
+        QVideoSink *sink = previewSink_;
+        session_->setPreviewCallback([sink](const videoCore::Frame &frame) {
+            if (frame.frame == nullptr) {
+                return;
+            }
+            QVideoFrameFormat fmt(QSize(frame.width, frame.height),
+                                  QVideoFrameFormat::Format_YUV420P);
+            QVideoFrame qFrame(fmt);
+            if (!qFrame.map(QVideoFrame::WriteOnly)) {
+                return;
+            }
+            for (int p = 0; p < 3; ++p) {
+                const int srcStride = frame.frame->linesize[p];
+                const int dstStride = qFrame.bytesPerLine(p);
+                const int planeH    = (p == 0) ? frame.height : frame.height / 2;
+                const int copyW     = std::min(srcStride, dstStride);
+                const auto *src     = frame.frame->data[p];
+                auto       *dst     = qFrame.bits(p);
+                for (int row = 0; row < planeH; ++row) {
+                    std::memcpy(
+                        dst + static_cast<std::ptrdiff_t>(row) * dstStride,
+                        src + static_cast<std::ptrdiff_t>(row) * srcStride,
+                        static_cast<std::size_t>(copyW));
+                }
+            }
+            qFrame.unmap();
+            sink->setVideoFrame(qFrame);
+        });
+    }
 
-    connect(m_startWatcher, &QFutureWatcher<bool>::finished, this, [this]() {
-        const bool success = m_startWatcher->result();
-        m_startWatcher->deleteLater();
-        m_startWatcher = nullptr;
+    startWatcher_ = new QFutureWatcher<bool>(this);
+
+    connect(startWatcher_, &QFutureWatcher<bool>::finished, this, [this]() {
+        const bool success = startWatcher_->result();
+        startWatcher_->deleteLater();
+        startWatcher_ = nullptr;
 
         if (success) {
             emit sessionStarted();
@@ -41,15 +77,27 @@ void CameraSessionController::start(const QString &whipUrl,
 
     std::shared_ptr<CameraSession> session = session_;
 
-    m_startFuture = QtConcurrent::run([this, std_url, std_key]() {
+    startFuture_ = QtConcurrent::run([this, std_url, std_key]() {
         qDebug() << "[CameraSessionController] Starting session.";
         return session_->start(std_url, std_key);
     });
 
-    m_startWatcher->setFuture(m_startFuture);
+    startWatcher_->setFuture(startFuture_);
 }
 
 void CameraSessionController::stop() {
     session_->stop();
     emit sessionStopped();
+}
+
+QVideoSink *CameraSessionController::previewSink() const {
+    return previewSink_;
+}
+
+void CameraSessionController::setPreviewSink(QVideoSink *sink) {
+    if (previewSink_ == sink) {
+        return;
+    }
+    previewSink_ = sink;
+    emit previewSinkChanged();
 }

--- a/client/src/session/session_controller.hpp
+++ b/client/src/session/session_controller.hpp
@@ -3,6 +3,7 @@
 #include <QQmlEngine>
 #include <QFuture>
 #include <QFutureWatcher>
+#include <QVideoSink>
 #include <memory>
 #include "camera_session.hpp"
 
@@ -10,6 +11,8 @@ class CameraSessionController : public QObject {
     Q_OBJECT
     QML_ELEMENT
     QML_SINGLETON
+
+    Q_PROPERTY(QVideoSink *previewSink READ previewSink WRITE setPreviewSink NOTIFY previewSinkChanged)
 
 public:
     explicit CameraSessionController(QObject *parent = nullptr);
@@ -22,13 +25,18 @@ public:
     Q_INVOKABLE void start(const QString &whipUrl, const QString &streamKey);
     Q_INVOKABLE void stop();
 
+    QVideoSink *previewSink() const;
+    void setPreviewSink(QVideoSink *sink);
+
 signals:
     void sessionStarted();
     void sessionStopped();
     void errorOccurred(const QString &message);
+    void previewSinkChanged();
 
 private:
     std::shared_ptr<CameraSession> session_;
-    QFuture<bool> m_startFuture;
-    QFutureWatcher<bool> *m_startWatcher = nullptr;
+    QFuture<bool> startFuture_;
+    QFutureWatcher<bool> *startWatcher_ = nullptr;
+    QVideoSink *previewSink_ = nullptr;
 };

--- a/client/src/ui/controls/CameraFeed.qml
+++ b/client/src/ui/controls/CameraFeed.qml
@@ -39,6 +39,8 @@ Thumbnail {
         if (assigned_track !== null) {
             assigned_track.setVideoSink(dl_video_output.videoSink);
         }
+
+        dl_video_output.clearOutput();
     }
 
     VideoOutput {

--- a/client/src/ui/controls/CameraFeed.qml
+++ b/client/src/ui/controls/CameraFeed.qml
@@ -37,7 +37,7 @@ Thumbnail {
 
     onAssigned_trackChanged: {
         if (assigned_track !== null) {
-            assigned_track.setVideoSink(dl_video_output.videoSink);
+            assigned_track.videoSink = dl_video_output.videoSink;
         }
 
         dl_video_output.clearOutput();

--- a/client/src/ui/controls/DLPopup.qml
+++ b/client/src/ui/controls/DLPopup.qml
@@ -61,6 +61,7 @@ Popup {
             font.pointSize: 14
             horizontalAlignment: Text.AlignHCenter
             verticalAlignment: Text.AlignVCenter
+            wrapMode: Text.WordWrap
         }
 
         RowLayout {

--- a/client/src/videotrack.cpp
+++ b/client/src/videotrack.cpp
@@ -29,7 +29,7 @@ bool VideoTrack::setTrack(const std::shared_ptr<livekit::Track> &track) {
     unsetTrack();
 
     livekit::VideoStream::Options opts;
-    opts.format = livekit::VideoBufferType::RGBA;
+    opts.format = livekit::VideoBufferType::I420;
 
     m_stream = livekit::VideoStream::fromTrack(track, opts);
     if (!m_stream) {

--- a/client/tests/test_livekit_room.cpp
+++ b/client/tests/test_livekit_room.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[]) {
     QEventLoop room_connect_loop;
     QEventLoop close_loop;
 
-    client.connectToServer(QUrl("http://localhost:50051"));
+    client.connectToServer(QUrl("http://34.174.71.83:50051"));
 
     // ------------------------------------
     // ERROR HANDLER

--- a/client/tests/test_livekit_room.cpp
+++ b/client/tests/test_livekit_room.cpp
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
     QString room_code;
     QString token;
     QString livekit_url;
-    bool isConnected = false;
+    bool is_connected = false;
     bool close_state = false;
 
     QEventLoop creation_loop;
@@ -34,7 +34,7 @@ int main(int argc, char *argv[]) {
     // ------------------------------------
 
     QObject::connect(&client, &SessionClient::error, &app, [&](const QString &msg) {
-        qCritical() << "An error occurred:" << msg;
+        qCritical() << "[Test] A signaling error occurred:" << msg;
     });
 
     // ------------------------------------
@@ -46,14 +46,14 @@ int main(int argc, char *argv[]) {
         creation_loop.quit();
     });
 
-    qDebug() << "Creating Session...";
+    qDebug() << "[Test] Creating Session...";
 
     client.createSession(user_id_director, max_cameras);
     creation_loop.exec();
 
     Q_ASSERT(!room_code.isEmpty());
 
-    qDebug() << "Session Created.";
+    qDebug() << "[Test] Session Created.";
 
     // ------------------------------------
     // SESSION JOIN
@@ -65,53 +65,53 @@ int main(int argc, char *argv[]) {
         d_join_loop.quit();
     });
 
-    qDebug() << "Joining Director...";
+    qDebug() << "[Test] Joining Director...";
     client.joinSession(room_code, user_id_director, "director");
     d_join_loop.exec();
 
     Q_ASSERT(!token.isEmpty());
     Q_ASSERT(!livekit_url.isEmpty());
 
-    qDebug() << "Director joined.";
+    qDebug() << "[Test] Director joined.";
 
     // ------------------------------------
     // LIVEKIT CONNECT
     // ------------------------------------
 
     QObject::connect(&transport, &DirectorTransport::connected, &room_connect_loop, [&]() {
-        isConnected = true;
+        is_connected = true;
         room_connect_loop.quit();
     });
 
-    qDebug() << "Connecting...";
+    qDebug() << "[Test] Connecting...";
     transport.connectToRoom(token, livekit_url);
     // 10-second timeout
     QTimer::singleShot(10000, &room_connect_loop, &QEventLoop::quit);
     room_connect_loop.exec();
 
-    if (!isConnected) {
-        qWarning() << "Timed out waiting for connection.";
+    if (!is_connected) {
+        qWarning() << "[Test] Timed out waiting for connection.";
         client.closeSession(room_code, user_id_director);
         return 1;
     }
 
-    qDebug() << "Director connected.";
+    qDebug() << "[Test] Director connected.";
 
     // ------------------------------------
     // LIVEKIT DISCONNECT
     // ------------------------------------
 
-    // Synchronous: isConnected should already be false before Q_ASSERT if the disconnect succeeds
+    // Synchronous: is_connected should already be false before Q_ASSERT if the disconnect succeeds
     QObject::connect(&transport, &DirectorTransport::disconnected, &app, [&]() {
-        isConnected = false;
+        is_connected = false;
     });
 
-    qDebug() << "Disconnecting...";
+    qDebug() << "[Test] Disconnecting...";
     transport.disconnectFromRoom();
 
-    Q_ASSERT(!isConnected);
+    Q_ASSERT(!is_connected);
 
-    qDebug() << "Director disconnected.";
+    qDebug() << "[Test] Director disconnected.";
 
     // ------------------------------------
     // SESSION CLOSING
@@ -122,13 +122,13 @@ int main(int argc, char *argv[]) {
         close_loop.quit();
     });
 
-    qDebug() << "Closing Session...";
+    qDebug() << "[Test] Closing Session...";
     client.closeSession(room_code, user_id_director);
     close_loop.exec();
 
     Q_ASSERT(close_state);
 
-    qDebug() << "Success.";
+    qDebug() << "[Test] Success.";
 
     livekit::shutdown();
     return 0;

--- a/client/tests/test_operator_session.cpp
+++ b/client/tests/test_operator_session.cpp
@@ -1,0 +1,190 @@
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QDebug>
+#include <QTimer>
+#include <QCommandLineParser>
+#include <gst/gst.h>
+#include "sessionclient.hpp"
+#include "session_controller.hpp"
+
+// ----------------------------------------
+// Usage: ./build/test_operator_session [--server <signaling_url>]
+// Default signaling url: http://34.174.71.83:50051
+// ----------------------------------------
+int main(int argc, char *argv[]) {
+    gst_init(&argc, &argv);
+    QCoreApplication app(argc, argv);
+
+    QCommandLineParser parser;
+    parser.addOption({"server", "Signaling server URL", "url", "http://34.174.71.83:50051"});
+    parser.process(app);
+
+    const QUrl server_url(parser.value("server"));
+
+    SessionClient client;
+    CameraSessionController cam_session_control = CameraSessionController();
+
+    QString user_id_director = "director-1";
+    QString user_id_camera = "camera-1";
+    int max_cameras = 1;
+    QString room_code;
+    QString token;
+    QString livekit_url;
+    QString stream_key;
+    QString whip_url;
+    bool is_cam_running = false;
+    bool close_state = false;
+
+    QEventLoop creation_loop;
+    QEventLoop d_join_loop;
+    QEventLoop c_join_loop;
+    QEventLoop cam_start_loop;
+    QEventLoop cam_stop_loop;
+    QEventLoop close_loop;
+
+    client.connectToServer(server_url);
+
+    // ------------------------------------
+    // ERROR HANDLER
+    // ------------------------------------
+
+    QObject::connect(&client, &SessionClient::error, &app, [&](const QString &msg) {
+        qCritical() << "[Test] A signaling error occurred:" << msg;
+    });
+
+    QObject::connect(&cam_session_control, &CameraSessionController::errorOccurred, &app, [&](const QString &msg) {
+        qCritical() << "[Test] A camera session error occurred:" << msg;
+    });
+
+    // ------------------------------------
+    // SESSION CREATION
+    // ------------------------------------
+
+    QObject::connect(&client, &SessionClient::sessionCreated, &creation_loop, [&](const QString &c) {
+        room_code = c;
+        creation_loop.quit();
+    });
+
+    qDebug() << "[Test] Creating Session...";
+
+    client.createSession(user_id_director, max_cameras);
+    creation_loop.exec();
+
+    Q_ASSERT(!room_code.isEmpty());
+
+    qDebug() << "[Test] Session Created.";
+
+    // ------------------------------------
+    // DIRECTOR SESSION JOIN
+    // ------------------------------------
+
+    QObject::connect(&client, &SessionClient::directorJoined, &d_join_loop, [&](const QString &t, const QString &l) {
+        token = t;
+        livekit_url = l;
+        d_join_loop.quit();
+    });
+
+    qDebug() << "[Test] Joining Director...";
+    client.joinSession(room_code, user_id_director, "director");
+    d_join_loop.exec();
+
+    Q_ASSERT(!token.isEmpty());
+    Q_ASSERT(!livekit_url.isEmpty());
+
+    qDebug() << "[Test] Director joined.";
+    
+    // ------------------------------------
+    // OPERATOR SESSION JOIN
+    // ------------------------------------
+
+    QObject::connect(&client, &SessionClient::cameraJoined, &c_join_loop, [&](const QString &w, const QString &s) {
+        whip_url = w;
+        stream_key = s;
+        c_join_loop.quit();
+    });
+
+    qDebug() << "[Test] Joining Operator...";
+    client.joinSession(room_code, user_id_camera, "camera");
+    c_join_loop.exec();
+
+    Q_ASSERT(!whip_url.isEmpty());
+    Q_ASSERT(!stream_key.isEmpty());
+
+    qDebug() << "[Test] Operator joined.";
+
+    // ------------------------------------
+    // CAMERA SESSION START
+    // ------------------------------------
+
+    QObject::connect(&cam_session_control, &CameraSessionController::sessionStarted, &cam_start_loop, [&]() {
+        is_cam_running = true;
+        cam_start_loop.quit();
+    });
+
+    qDebug() << "[Test] Starting Camera Session...";
+    cam_session_control.start(whip_url, stream_key);
+    
+    // 25-second timeout
+    QTimer::singleShot(25000, &cam_start_loop, &QEventLoop::quit);
+    cam_start_loop.exec();
+
+    if (!is_cam_running) {
+        qCritical() << "[Test] Timed out waiting for camera session";
+        client.closeSession(room_code, user_id_director);
+        QEventLoop abort_close;
+        QObject::connect(&client, &SessionClient::sessionClosed, &abort_close,
+                         [&](bool) { abort_close.quit(); });
+        abort_close.exec();
+        gst_deinit();
+        return 1;
+    }
+
+    qDebug() << "[Test] Camera Session started.";
+
+    // ------------------------------------
+    // STREAM
+    // ------------------------------------
+
+    QEventLoop stream_loop;
+    QTimer::singleShot(10000, &stream_loop, &QEventLoop::quit);
+    stream_loop.exec();
+
+    // ------------------------------------
+    // CAMERA SESSION STOP
+    // ------------------------------------
+
+    QObject::connect(&cam_session_control, &CameraSessionController::sessionStopped, &cam_stop_loop, [&]() {
+        is_cam_running = false;
+        cam_stop_loop.quit();
+    });
+
+    qDebug() << "[Test] Stopping Camera Session...";
+    cam_session_control.stop();
+    cam_stop_loop.exec();
+
+    Q_ASSERT(!is_cam_running);
+
+    qDebug() << "[Test] Camera Session Stopped.";
+
+    // ------------------------------------
+    // SESSION CLOSING
+    // ------------------------------------
+
+    QObject::connect(&client, &SessionClient::sessionClosed, &close_loop, [&](bool success) {
+        close_state = success;
+        close_loop.quit();
+    });
+
+    qDebug() << "[Test] Closing Session...";
+    client.closeSession(room_code, user_id_director);
+    close_loop.exec();
+
+    Q_ASSERT(close_state);    
+
+    qDebug() << "[Test] Session closed.";
+
+    // ------------------------------------
+
+    qDebug() << "[Test] Success.";
+    return 0;
+}

--- a/client/tests/test_signaling_client.cpp
+++ b/client/tests/test_signaling_client.cpp
@@ -31,7 +31,7 @@ int main(int argc, char *argv[]) {
     // ------------------------------------
 
     QObject::connect(&client, &SessionClient::error, &app, [&](const QString &msg) {
-        qCritical() << "An error occurred:" << msg;
+        qCritical() << "[Test] A signaling error occurred:" << msg;
     });
 
     // ------------------------------------
@@ -43,14 +43,14 @@ int main(int argc, char *argv[]) {
         creation_loop.quit();
     });
 
-    qDebug() << "Creating Session...";
+    qDebug() << "[Test] Creating Session...";
 
     client.createSession(user_id_director, max_cameras);
     creation_loop.exec();
 
     Q_ASSERT(!room_code.isEmpty());
 
-    qDebug() << "Session Created.";
+    qDebug() << "[Test] Session Created.";
 
     // ------------------------------------
     // DIRECTOR SESSION JOIN
@@ -62,14 +62,14 @@ int main(int argc, char *argv[]) {
         d_join_loop.quit();
     });
 
-    qDebug() << "Joining Director...";
+    qDebug() << "[Test] Joining Director...";
     client.joinSession(room_code, user_id_director, "director");
     d_join_loop.exec();
 
     Q_ASSERT(!token.isEmpty());
     Q_ASSERT(!livekit_url.isEmpty());
 
-    qDebug() << "Director joined.";
+    qDebug() << "[Test] Director joined.";
 
     // ------------------------------------
     // OPERATOR SESSION JOIN
@@ -81,14 +81,14 @@ int main(int argc, char *argv[]) {
         c_join_loop.quit();
     });
 
-    qDebug() << "Joining Operator...";
+    qDebug() << "[Test] Joining Operator...";
     client.joinSession(room_code, user_id_camera, "camera");
     c_join_loop.exec();
 
     Q_ASSERT(!whip_url.isEmpty());
     Q_ASSERT(!stream_key.isEmpty());
 
-    qDebug() << "Operator joined.";
+    qDebug() << "[Test] Operator joined.";
 
     // ------------------------------------
     // SESSION CLOSING
@@ -99,13 +99,13 @@ int main(int argc, char *argv[]) {
         close_loop.quit();
     });
 
-    qDebug() << "Closing Session...";
+    qDebug() << "[Test] Closing Session...";
     client.closeSession(room_code, user_id_director);
     close_loop.exec();
 
     Q_ASSERT(close_state);
 
-    qDebug() << "Success.";
+    qDebug() << "[Test] Success.";
 
     return 0;
 }

--- a/client/tests/test_signaling_client.cpp
+++ b/client/tests/test_signaling_client.cpp
@@ -24,7 +24,7 @@ int main(int argc, char *argv[]) {
     QEventLoop c_join_loop;
     QEventLoop close_loop;
 
-    client.connectToServer(QUrl("http://localhost:50051"));
+    client.connectToServer(QUrl("http://34.174.71.83:50051"));
 
     // ------------------------------------
     // ERROR HANDLER

--- a/networking/include/whip_publisher.hpp
+++ b/networking/include/whip_publisher.hpp
@@ -27,10 +27,15 @@ public:
     void pushPacket(std::unique_ptr<videoCore::Packet> packet);
     [[nodiscard]] bool isRunning() const noexcept { return running_; }
 
+    void setKeyframeRequestCallback(std::function<void()> cb) noexcept {
+        forceKeyframeCallback_ = std::move(cb);
+    }
+
 private:
     std::string whipUrl_;
     std::string streamKey_;
     std::function<void(std::string)> onErrorCallback_;
+    std::function<void()> forceKeyframeCallback_;
     bool running_ = false;
     GstElement *pipeline_ = nullptr;
     GstElement *appsrc_ = nullptr;

--- a/networking/src/whip_publisher.cpp
+++ b/networking/src/whip_publisher.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <gstreamer-1.0/gst/app/gstappsrc.h>
 #include <gstreamer-1.0/gst/gst.h>
+#include <gstreamer-1.0/gst/video/video.h>
 
 namespace networking {
 WHIPPublisher::~WHIPPublisher() {
@@ -95,6 +96,22 @@ WHIPPublisher::initialize(const std::string &whip_url,
         },
         this);
     gst_object_unref(bus);
+
+    
+    GstPad *appsrc_src = gst_element_get_static_pad(appsrc_, "src");
+    gst_pad_add_probe(appsrc_src,
+        GST_PAD_PROBE_TYPE_EVENT_UPSTREAM,
+        [](GstPad *, GstPadProbeInfo *info, gpointer data) -> GstPadProbeReturn {
+            auto *self = static_cast<WHIPPublisher *>(data);
+            GstEvent *event = GST_PAD_PROBE_INFO_EVENT(info);
+            if ((gst_video_event_is_force_key_unit(event) != 0) &&
+                    self->forceKeyframeCallback_) {
+                self->forceKeyframeCallback_();
+            }
+            return GST_PAD_PROBE_OK;
+        },
+        this, nullptr);
+    gst_object_unref(appsrc_src);
 
     return Result::Success;
 }

--- a/video-core/include/capture/capture_config.hpp
+++ b/video-core/include/capture/capture_config.hpp
@@ -7,6 +7,7 @@ struct CaptureConfig {
     std::string devicePath =
         "/dev/video0";                // Linux: /dev/video0, Windows: "video=0"
     std::string inputFormat = "v4l2"; // Linux: v4l2, Windows: dshow
+    std::string pixelFormat;          // e.g. "mjpeg", "yuyv422"
     int width = 0;
     int height = 0;
     int framerate = 30;

--- a/video-core/include/encode/encoder.hpp
+++ b/video-core/include/encode/encoder.hpp
@@ -20,6 +20,8 @@ public:
                std::function<void(std::unique_ptr<Packet>)> packetCallback);
     [[nodiscard]] virtual Result encodeFrame(AVFrame *frame) = 0;
     virtual void stop() = 0;
+    // Requests an IDR (instantaneous decoder refresh) to allow remote decoder to recover after packet loss
+    virtual void requestKeyframe() noexcept {}
 
     [[nodiscard]] virtual bool isRunning() const { return running_; };
 

--- a/video-core/include/encode/software_encoder.hpp
+++ b/video-core/include/encode/software_encoder.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "encoder.hpp"
 #include "encoder_config.hpp"
+#include <atomic>
 
 struct AVCodecContext;
 
@@ -19,8 +20,10 @@ public:
         std::function<void(std::unique_ptr<Packet>)> packetCallback) override;
     [[nodiscard]] Result encodeFrame(AVFrame *frame) override;
     void stop() override;
+    void requestKeyframe() noexcept override;
 
 private:
     AVCodecContext *codecCtx_ = nullptr;
+    std::atomic<bool> forceKeyframe_ = false;
 };
 } // namespace videoCore::encode

--- a/video-core/include/pipeline/video_pipeline.hpp
+++ b/video-core/include/pipeline/video_pipeline.hpp
@@ -30,6 +30,9 @@ public:
     start(std::function<void(std::unique_ptr<Packet>)> packetCallback);
     [[nodiscard]] Result stop();
 
+    // Forward keyframe request to encoder. Thread-safe
+    void requestKeyframe() noexcept;
+
     // Optional callback to receive raw frame before encoding.
     // Must be set before start().
     void setPreviewCallback(std::function<void(const Frame &)> previewCallback);

--- a/video-core/include/pipeline/video_pipeline.hpp
+++ b/video-core/include/pipeline/video_pipeline.hpp
@@ -30,6 +30,10 @@ public:
     start(std::function<void(std::unique_ptr<Packet>)> packetCallback);
     [[nodiscard]] Result stop();
 
+    // Optional callback to receive raw frame before encoding.
+    // Must be set before start().
+    void setPreviewCallback(std::function<void(const Frame &)> previewCallback);
+
     // Statistics getters
     [[nodiscard]] int getCurrentFramerate() const noexcept {
         return currentFramerate_;
@@ -70,6 +74,7 @@ private:
     std::unique_ptr<capture::CameraCapture> captureDevice_;
     std::unique_ptr<encode::Encoder> encoder_;
     std::function<void(std::unique_ptr<Packet>)> packetCallback_;
+    std::function<void(const Frame &)> previewCallback_;
 
     // Frame queue  between capture and encode threads
     std::queue<std::unique_ptr<Frame>> frameQueue_;

--- a/video-core/src/capture/camera_capture.cpp
+++ b/video-core/src/capture/camera_capture.cpp
@@ -96,6 +96,11 @@ Result CameraCapture::setupDevice() {
                     std::to_string(config_.framerate).c_str(), 0);
     }
 
+    if (!config_.pixelFormat.empty()) {
+        av_dict_set(&options, "input_format", 
+                    config_.pixelFormat.c_str(), 0);
+    }
+
     formatCtx_ = avformat_alloc_context();
     if (avformat_open_input(&formatCtx_, config_.devicePath.c_str(), input_fmt,
                             &options) < 0) {

--- a/video-core/src/encode/software_encoder.cpp
+++ b/video-core/src/encode/software_encoder.cpp
@@ -49,6 +49,8 @@ Result SoftwareEncoder::initialize(
     codecCtx_->gop_size = config_.gopSize;
     codecCtx_->max_b_frames = 0;             // No B-frames for low latency
     codecCtx_->pix_fmt = AV_PIX_FMT_YUV420P; // Common pixel format
+    codecCtx_->color_range = AVCOL_RANGE_MPEG; // 16-235/16-240 range
+    codecCtx_->profile = FF_PROFILE_H264_CONSTRAINED_BASELINE; // For WebRTC
 
     // Set preset options (e.g., ultrafast, fast, medium, slow)
     AVDictionary *options = nullptr;
@@ -70,6 +72,8 @@ Result SoftwareEncoder::initialize(
     // disables encoder features that add latency (e.g., B-frames, lookahead)
     av_dict_set(&options, "tune", "zerolatency", 0);
 
+    av_dict_set(&options, "profile", "baseline", 0);
+
     if (avcodec_open2(codecCtx_, encoder, &options) < 0) {
         av_dict_free(&options);
         return Result::ErrorInitFailed; // Failed to open codec
@@ -80,16 +84,42 @@ Result SoftwareEncoder::initialize(
     return Result::Success;
 }
 
+void SoftwareEncoder::requestKeyframe() noexcept {
+    forceKeyframe_.store(true, std::memory_order_release);
+}
+
 Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
     if (!running_) {
         return Result::ErrorEncodeFailed; // Not initialized
     }
 
-    // Convert frame to YUV420P with proper stride if needed
+    auto src_fmt = static_cast<AVPixelFormat>(frame->format);
+    bool src_full_range = (frame->color_range == AVCOL_RANGE_JPEG);
+    switch (src_fmt) {
+        case AV_PIX_FMT_YUVJ420P:
+            src_fmt = AV_PIX_FMT_YUV420P;
+            src_full_range = true;
+            break;
+        case AV_PIX_FMT_YUVJ422P:
+            src_fmt = AV_PIX_FMT_YUV422P;
+            src_full_range = true;
+            break;
+        case AV_PIX_FMT_YUVJ444P:
+            src_fmt = AV_PIX_FMT_YUV444P;
+            src_full_range = true;
+            break;
+        default: break;
+    }
+
+    // Convert frame to YUV420P with limited range if needed
     AVFrame *input_frame = frame;
     AVFrame *converted_frame = nullptr;
 
-    if (frame->format != AV_PIX_FMT_YUV420P || frame->linesize[0] == 0) {
+    if (src_fmt != AV_PIX_FMT_YUV420P ||
+        src_full_range ||
+        frame->width != codecCtx_->width ||
+        frame->height != codecCtx_->height ||
+        frame->linesize[0] == 0) {
         converted_frame = av_frame_alloc();
         converted_frame->width = codecCtx_->width;
         converted_frame->height = codecCtx_->height;
@@ -98,19 +128,32 @@ Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
 
         // Convert to YUV420P if needed
         SwsContext *sws_ctx = sws_getContext(
-            frame->width, frame->height,
-            static_cast<AVPixelFormat>(frame->format), codecCtx_->width,
-            codecCtx_->height, AV_PIX_FMT_YUV420P, SWS_BILINEAR, nullptr,
-            nullptr, nullptr);
+            frame->width, frame->height, src_fmt,
+            codecCtx_->width, codecCtx_->height, AV_PIX_FMT_YUV420P, 
+            SWS_BILINEAR, nullptr, nullptr, nullptr);
 
         // Perform conversion if swsCtx is valid
         if (sws_ctx != nullptr) {
+            if (src_full_range) {
+                // Maps JPEG full-range (0-255) luma/chroma to H.264 limited-range
+                // (16-235 / 16-240) so that the colors are not washed out at the decoder
+                sws_setColorspaceDetails(sws_ctx, 
+                    sws_getCoefficients(SWS_CS_DEFAULT), 1, // full range @ src
+                    sws_getCoefficients(SWS_CS_DEFAULT), 0, // limited range @ destination
+                    0, 1 << 16, 1 << 16);
+            }
             sws_scale(sws_ctx, frame->data, frame->linesize, 0, frame->height,
                       converted_frame->data, converted_frame->linesize);
             sws_freeContext(sws_ctx);
             converted_frame->pts = frame->pts;
             input_frame = converted_frame;
         }
+    }
+
+    // Emit an IDR this frame so remote decoder can recover without
+    // waiting for the next scheduled GOP
+    if (forceKeyframe_.exchange(false, std::memory_order_acq_rel)) {
+        input_frame->pict_type = AV_PICTURE_TYPE_I;
     }
 
     // Convert PTS from nanoseconds to encoder timebase

--- a/video-core/src/pipeline/video_pipeline.cpp
+++ b/video-core/src/pipeline/video_pipeline.cpp
@@ -51,6 +51,9 @@ Result VideoPipeline::start(
     auto capture_result =
         captureDevice_->start([this](std::unique_ptr<Frame> frame) {
             {
+                if (previewCallback_) {
+                    previewCallback_(*frame);
+                }
                 std::lock_guard<std::mutex> lock(queueMutex_);
                 if (frameQueue_.size() >= QUEUE_CAPACITY) {
                     frameQueue_.pop(); // Drop oldest frame
@@ -69,6 +72,10 @@ Result VideoPipeline::start(
         [this](const std::stop_token &token) { encodeLoop(token); });
 
     return Result::Success;
+}
+
+void VideoPipeline::setPreviewCallback(std::function<void(const Frame &)> previewCallback) {
+    previewCallback_ = std::move(previewCallback);
 }
 
 Result VideoPipeline::stop() {

--- a/video-core/src/pipeline/video_pipeline.cpp
+++ b/video-core/src/pipeline/video_pipeline.cpp
@@ -74,6 +74,12 @@ Result VideoPipeline::start(
     return Result::Success;
 }
 
+void VideoPipeline::requestKeyframe() noexcept {
+    if (encoder_) {
+        encoder_->requestKeyframe();
+    }
+}
+
 void VideoPipeline::setPreviewCallback(std::function<void(const Frame &)> previewCallback) {
     previewCallback_ = std::move(previewCallback);
 }


### PR DESCRIPTION
## Summary
Implements all client-sided WHIP Publishing fixes. The app now uses a cloud endpoint as its channel to access the signaling server, and LiveKit server. An operator session test has been added to test the camera session. Additionally, the operator session view now pushes captured frames to the preview CameraFeed. Most changes are from the branch [example/whip-publisher-fixes](https://github.com/AaronBrownDev/direct-link/tree/example/whip-publisher-fixes).

## Changes

### `backend/configs/ingress.yaml`
- Directly set dev credentials that LiveKit/Ingress needs for docker-compose

### `client/CMakeLists.txt`
- Fetch the `fmt` package and includes it in the link libraries for `direct-link`
- Add a fetch for Microsoft GSL for if it is not already installed
- Add a target for `test_operator_session`

### `client/src/application/Main.qml`
- Set the channel url to the cloud endpoint instead of a local endpoint used by the porduction stack

### `client/src/application/views/SessionOperatorView.qml`
- Remove the QtMultimedia `CaptureSession` in favor of preview frames being pushed from the `CameraSession`

### `FrameReader` Class
- Directly copy YUV420P planes to the `QVideoFrame`

### `client/src/session/CMakeLists.txt`
- Add QtMultimedia as a dependency to support preview frame push

### `CameraSession` Class
- Update the capture config display setting to 1280x720 with a framerate of 30
- Add clearer debug output
- Swap the startup order of the WHIP Publisher and capture pipeline

### `CameraSessionController` Class
- Add preview sink property to store the video sink of a `CameraFeed` that displays an operatore's captured frames

### `client/src/ui/controls/CameraFeed.qml`
- Clear the video output when the feed's track is reassigned to prevent stale frame display

### `client/src/ui/controls/DLPopup.qml`
- Wrap messages to prevent long text from overflowing the popup window

### `client/src/videotrack.cpp`
- Switch to an `I420` video buffer type 

### `client/tests/test_livekit_room.cpp`
- Switch channel url to cloud endpoint
- Add a label to debug output

### `client/tests/test_operator_session.cpp`
- Add a test that creates a session and allows the operator to join and publish frames for 10 seconds

### `client/tests/test_signaling_client.cpp`
- Switch channel url to cloud endpoint
- Add a label to debug output

### `WHIPPublisher` Class
- Add Keyframe Request callback for when `gst_video_event_is_force_key_unit()` returns true

### `video-core/include/capture/capture_config.hpp`
- Add a pixel format setting

### `video-core/include/encode/encoder.hpp`
- Add a `requestKeyframe()` method

### `SoftwareEncoder` Class
- Emit an IDR when the `forceKeyframe_` flag is set

### `VideoPipeline` Class
- Forward `requestKeyframe()` to the encoder
- Pass captured frames to the set preview callback

Closes #198 