### PR TITLE
feat(signaling): input validation hardening on all gRPC endpoints

### DIFF
--- a/backend/internal/signaling/grpc.go
+++ b/backend/internal/signaling/grpc.go
@@ -17,14 +17,8 @@ import (
 func (s *Server) JoinSession(ctx context.Context, req *pb.JoinRequest) (*pb.JoinReply, error) {
 
 	// Validate required fields
-	if req.UserId == "" {
-		return nil, status.Error(codes.InvalidArgument, "user_id is required")
-	}
-	if req.Role == "" {
-		return nil, status.Error(codes.InvalidArgument, "role is required")
-	}
-	if req.RoomCode == "" {
-		return nil, status.Error(codes.InvalidArgument, "room_code is required")
+	if err := validateJoinRequest(req); err != nil {
+		return nil, err
 	}
 
 	// Resolve room code to session and verify it is active
@@ -120,12 +114,8 @@ func (s *Server) joinAsDirector(ctx context.Context, req *pb.JoinRequest, sess *
 func (s *Server) CreateSession(ctx context.Context, req *pb.CreateSessionRequest) (*pb.CreateSessionReply, error) {
 
 	// Validate required fields
-	if req.UserId == "" {
-		return nil, status.Error(codes.InvalidArgument, "user_id is required")
-	}
-	if req.MaxCameras <= 0 {
-		//TODO: Add camera limit
-		return nil, status.Error(codes.InvalidArgument, "max_cameras must be greater than zero")
+	if err := validateCreateSessionRequest(req); err != nil {
+		return nil, err
 	}
 
 	// Generate session ID and room code
@@ -179,11 +169,8 @@ func (s *Server) CreateSession(ctx context.Context, req *pb.CreateSessionRequest
 func (s *Server) CloseSession(ctx context.Context, req *pb.CloseSessionRequest) (*pb.CloseSessionReply, error) {
 
 	// Validate required fields
-	if req.RoomCode == "" {
-		return nil, status.Error(codes.InvalidArgument, "room_code is required")
-	}
-	if req.UserId == "" {
-		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	if err := validateCloseSessionRequest(req); err != nil {
+		return nil, err
 	}
 
 	// Retrieves session by room code
@@ -225,10 +212,9 @@ func (s *Server) CloseSession(ctx context.Context, req *pb.CloseSessionRequest) 
 // GetMySessions returns all sessions created by the requesting user
 func (s *Server) GetMySessions(ctx context.Context, req *pb.GetMySessionsRequest) (*pb.GetMySessionsReply, error) {
 	// Validate required fields
-	if req.UserId == "" {
-		return nil, status.Error(codes.InvalidArgument, "user_id is required")
+	if err := validateGetMySessionsRequest(req); err != nil {
+		return nil, err
 	}
-
 	// Fetch all sessions for this user
 	sessions, err := s.store.GetUserSessions(ctx, req.UserId)
 	if err != nil {

--- a/backend/internal/signaling/grpc_test.go
+++ b/backend/internal/signaling/grpc_test.go
@@ -152,7 +152,7 @@ func newUnitTestServer(t *testing.T, mockIngress *mockIngressClient, mockRoom *m
 func seedSession(t *testing.T, store session.Store) *session.Session {
 	t.Helper()
 	sess := &session.Session{
-		ID: "test-session-id", RoomCode: "ROOM-TEST", CreatedBy: "director-1",
+		ID: "test-session-id", RoomCode: "ROOM-123456", CreatedBy: "director-1",
 		CreatedAt: time.Now().UTC(), MaxCameras: 4, Status: "active",
 	}
 	if err := store.CreateSession(context.Background(), sess); err != nil {
@@ -229,7 +229,7 @@ func TestJoinSession(t *testing.T) {
 			seedSession(t, srv.store)
 
 			reply, err := srv.JoinSession(context.Background(), &pb.JoinRequest{
-				RoomCode: "ROOM-TEST",
+				RoomCode: "ROOM-123456",
 				UserId:   "user-1",
 				Role:     tt.role,
 			})
@@ -270,7 +270,7 @@ func TestJoinSession_CameraRole_StoresIngressID(t *testing.T) {
 	sess := seedSession(t, srv.store)
 
 	_, err := srv.JoinSession(context.Background(), &pb.JoinRequest{
-		RoomCode: "ROOM-TEST",
+		RoomCode: "ROOM-123456",
 		UserId:   "camera-1",
 		Role:     "camera",
 	})
@@ -291,7 +291,7 @@ func TestJoinSession_CameraRole_StoresIngressID(t *testing.T) {
 // and no partial state is left in Redis.
 func TestJoinSession_CameraRole_RollsBackIngressOnGrantAccessFailure(t *testing.T) {
 	seededSession := &session.Session{
-		ID: "test-session-id", RoomCode: "ROOM-TEST", CreatedBy: "director-1",
+		ID: "test-session-id", RoomCode: "ROOM-123456", CreatedBy: "director-1",
 		CreatedAt: time.Now().UTC(), MaxCameras: 4, Status: "active",
 	}
 	grantErr := errors.New("simulated GrantAccess failure")
@@ -424,7 +424,7 @@ func TestCloseSession_IngressCleanup(t *testing.T) {
 			}
 
 			_, err := srv.CloseSession(context.Background(), &pb.CloseSessionRequest{
-				RoomCode: "ROOM-TEST",
+				RoomCode: "ROOM-123456",
 				UserId:   "director-1",
 			})
 			if err != nil {

--- a/backend/internal/signaling/validate.go
+++ b/backend/internal/signaling/validate.go
@@ -1,0 +1,75 @@
+package signaling
+
+import (
+	"regexp"
+
+	pb "github.com/AaronBrownDev/direct-link/gen/proto/signaling"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	maxUserIDLength   = 64
+	maxCamerasAllowed = 4
+)
+
+var roomCodeRegex = regexp.MustCompile(`^ROOM-\d{6}$`)
+
+func validateRoomCode(code string) error {
+	if code == "" {
+		return status.Error(codes.InvalidArgument, "room_code is required")
+	}
+	if !roomCodeRegex.MatchString(code) {
+		return status.Error(codes.InvalidArgument, "room_code must match format ROOM-XXXXXX")
+	}
+
+	return nil
+}
+
+func validateUserID(id string) error {
+	if len(id) == 0 || len(id) > maxUserIDLength {
+		return status.Error(codes.InvalidArgument, "user_id must be between 1 and 64 characters")
+	}
+	return nil
+}
+
+func validateJoinRequest(req *pb.JoinRequest) error {
+	if err := validateRoomCode(req.RoomCode); err != nil {
+		return err
+	}
+	if err := validateUserID(req.UserId); err != nil {
+		return err
+	}
+
+	if req.Role != "camera" && req.Role != "director" {
+		return status.Error(codes.InvalidArgument, "role must be 'camera' or 'director'")
+	}
+	return nil
+}
+
+func validateCreateSessionRequest(req *pb.CreateSessionRequest) error {
+	if err := validateUserID(req.UserId); err != nil {
+		return err
+	}
+	if req.MaxCameras <= 0 || req.MaxCameras > maxCamerasAllowed {
+		return status.Error(codes.InvalidArgument, "max_cameras must be between 1 and 4")
+	}
+	return nil
+}
+
+func validateCloseSessionRequest(req *pb.CloseSessionRequest) error {
+	if err := validateRoomCode(req.RoomCode); err != nil {
+		return err
+	}
+	if err := validateUserID(req.UserId); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateGetMySessionsRequest(req *pb.GetMySessionsRequest) error {
+	if err := validateUserID(req.UserId); err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/internal/signaling/validate.go
+++ b/backend/internal/signaling/validate.go
@@ -13,8 +13,12 @@ const (
 	maxCamerasAllowed = 4
 )
 
+// roomCodeRegex is compiled once at package init for performance
+// Valid format ROOM-XXXXXX where X is a digit (e.g. ROOM-XXXXXX)
 var roomCodeRegex = regexp.MustCompile(`^ROOM-\d{6}$`)
 
+// validateRoomCode is a shared helper used by any request that carries a room code.
+// Empty and malformed inputs produce distinct error messages
 func validateRoomCode(code string) error {
 	if code == "" {
 		return status.Error(codes.InvalidArgument, "room_code is required")
@@ -26,6 +30,7 @@ func validateRoomCode(code string) error {
 	return nil
 }
 
+// validateUserID is a shared helper used by every request that carries a user_id.
 func validateUserID(id string) error {
 	if len(id) == 0 || len(id) > maxUserIDLength {
 		return status.Error(codes.InvalidArgument, "user_id must be between 1 and 64 characters")
@@ -33,6 +38,7 @@ func validateUserID(id string) error {
 	return nil
 }
 
+// validateJoinRequest validates a JoinSession request
 func validateJoinRequest(req *pb.JoinRequest) error {
 	if err := validateRoomCode(req.RoomCode); err != nil {
 		return err
@@ -47,6 +53,7 @@ func validateJoinRequest(req *pb.JoinRequest) error {
 	return nil
 }
 
+// validateCreateSessionRequest validates a CreateSession request
 func validateCreateSessionRequest(req *pb.CreateSessionRequest) error {
 	if err := validateUserID(req.UserId); err != nil {
 		return err
@@ -57,6 +64,7 @@ func validateCreateSessionRequest(req *pb.CreateSessionRequest) error {
 	return nil
 }
 
+// validateCloseSessionRequest validates a CloseSession request
 func validateCloseSessionRequest(req *pb.CloseSessionRequest) error {
 	if err := validateRoomCode(req.RoomCode); err != nil {
 		return err
@@ -67,6 +75,7 @@ func validateCloseSessionRequest(req *pb.CloseSessionRequest) error {
 	return nil
 }
 
+// validateGetMySessionsRequest validates a GetMySessions request
 func validateGetMySessionsRequest(req *pb.GetMySessionsRequest) error {
 	if err := validateUserID(req.UserId); err != nil {
 		return err

--- a/backend/internal/signaling/validate_test.go
+++ b/backend/internal/signaling/validate_test.go
@@ -1,0 +1,362 @@
+package signaling
+
+import (
+	"strings"
+	"testing"
+
+	pb "github.com/AaronBrownDev/direct-link/gen/proto/signaling"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// assertInvalidArgument is a helper that checks the error is a gRPC
+// InvalidArgument status containing the expected message substring.
+func assertInvalidArgument(t *testing.T, err error, msgSubstring string) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	st, ok := status.FromError(err)
+	if !ok {
+		t.Fatalf("expected gRPC status error, got %T: %v", err, err)
+	}
+	if st.Code() != codes.InvalidArgument {
+		t.Errorf("expected code InvalidArgument, got %s", st.Code())
+	}
+	if !strings.Contains(st.Message(), msgSubstring) {
+		t.Errorf("expected message to contain %q, got %q", msgSubstring, st.Message())
+	}
+}
+
+// --- validateRoomCode ---
+
+func TestValidateRoomCode(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:    "valid room code",
+			input:   "ROOM-000472",
+			wantErr: false,
+		},
+		{
+			name:       "empty room code",
+			input:      "",
+			wantErr:    true,
+			wantSubstr: "room_code is required",
+		},
+		{
+			name:       "missing ROOM prefix",
+			input:      "000472",
+			wantErr:    true,
+			wantSubstr: "room_code must match format ROOM-XXXXXX",
+		},
+		{
+			name:       "too few digits",
+			input:      "ROOM-123",
+			wantErr:    true,
+			wantSubstr: "room_code must match format ROOM-XXXXXX",
+		},
+		{
+			name:       "too many digits",
+			input:      "ROOM-1234567",
+			wantErr:    true,
+			wantSubstr: "room_code must match format ROOM-XXXXXX",
+		},
+		{
+			name:       "letters in digit section",
+			input:      "ROOM-ABCDEF",
+			wantErr:    true,
+			wantSubstr: "room_code must match format ROOM-XXXXXX",
+		},
+		{
+			name:       "lowercase prefix",
+			input:      "room-000472",
+			wantErr:    true,
+			wantSubstr: "room_code must match format ROOM-XXXXXX",
+		},
+		{
+			name:       "missing hyphen",
+			input:      "ROOM000472",
+			wantErr:    true,
+			wantSubstr: "room_code must match format ROOM-XXXXXX",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRoomCode(tt.input)
+			if tt.wantErr {
+				assertInvalidArgument(t, err, tt.wantSubstr)
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// --- validateUserID ---
+
+func TestValidateUserID(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{
+			name:    "valid short id",
+			input:   "director-1",
+			wantErr: false,
+		},
+		{
+			name:    "valid 64 character id",
+			input:   strings.Repeat("a", 64),
+			wantErr: false,
+		},
+		{
+			name:    "empty id",
+			input:   "",
+			wantErr: true,
+		},
+		{
+			name:    "65 character id",
+			input:   strings.Repeat("a", 65),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateUserID(tt.input)
+			if tt.wantErr {
+				assertInvalidArgument(t, err, "user_id must be between 1 and 64 characters")
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// --- validateJoinRequest ---
+
+func TestValidateJoinRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		req        *pb.JoinRequest
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:    "valid camera request",
+			req:     &pb.JoinRequest{RoomCode: "ROOM-000472", UserId: "camera-1", Role: "camera"},
+			wantErr: false,
+		},
+		{
+			name:    "valid director request",
+			req:     &pb.JoinRequest{RoomCode: "ROOM-000472", UserId: "director-1", Role: "director"},
+			wantErr: false,
+		},
+		{
+			name:       "empty room code",
+			req:        &pb.JoinRequest{RoomCode: "", UserId: "camera-1", Role: "camera"},
+			wantErr:    true,
+			wantSubstr: "room_code is required",
+		},
+		{
+			name:       "malformed room code",
+			req:        &pb.JoinRequest{RoomCode: "ROOM-ABC", UserId: "camera-1", Role: "camera"},
+			wantErr:    true,
+			wantSubstr: "room_code must match format ROOM-XXXXXX",
+		},
+		{
+			name:       "empty user id",
+			req:        &pb.JoinRequest{RoomCode: "ROOM-000472", UserId: "", Role: "camera"},
+			wantErr:    true,
+			wantSubstr: "user_id must be between 1 and 64 characters",
+		},
+		{
+			name:       "user id too long",
+			req:        &pb.JoinRequest{RoomCode: "ROOM-000472", UserId: strings.Repeat("a", 65), Role: "camera"},
+			wantErr:    true,
+			wantSubstr: "user_id must be between 1 and 64 characters",
+		},
+		{
+			name:       "invalid role",
+			req:        &pb.JoinRequest{RoomCode: "ROOM-000472", UserId: "user-1", Role: "admin"},
+			wantErr:    true,
+			wantSubstr: "role must be 'camera' or 'director'",
+		},
+		{
+			name:       "empty role",
+			req:        &pb.JoinRequest{RoomCode: "ROOM-000472", UserId: "user-1", Role: ""},
+			wantErr:    true,
+			wantSubstr: "role must be 'camera' or 'director'",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateJoinRequest(tt.req)
+			if tt.wantErr {
+				assertInvalidArgument(t, err, tt.wantSubstr)
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// --- validateCreateSessionRequest ---
+
+func TestValidateCreateSessionRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		req        *pb.CreateSessionRequest
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:    "valid request",
+			req:     &pb.CreateSessionRequest{UserId: "director-1", MaxCameras: 4},
+			wantErr: false,
+		},
+		{
+			name:    "min cameras",
+			req:     &pb.CreateSessionRequest{UserId: "director-1", MaxCameras: 1},
+			wantErr: false,
+		},
+		{
+			name:       "empty user id",
+			req:        &pb.CreateSessionRequest{UserId: "", MaxCameras: 4},
+			wantErr:    true,
+			wantSubstr: "user_id must be between 1 and 64 characters",
+		},
+		{
+			name:       "user id too long",
+			req:        &pb.CreateSessionRequest{UserId: strings.Repeat("a", 65), MaxCameras: 4},
+			wantErr:    true,
+			wantSubstr: "user_id must be between 1 and 64 characters",
+		},
+		{
+			name:       "zero cameras",
+			req:        &pb.CreateSessionRequest{UserId: "director-1", MaxCameras: 0},
+			wantErr:    true,
+			wantSubstr: "max_cameras must be between 1 and 4",
+		},
+		{
+			name:       "too many cameras",
+			req:        &pb.CreateSessionRequest{UserId: "director-1", MaxCameras: 5},
+			wantErr:    true,
+			wantSubstr: "max_cameras must be between 1 and 4",
+		},
+		{
+			name:       "negative cameras",
+			req:        &pb.CreateSessionRequest{UserId: "director-1", MaxCameras: -1},
+			wantErr:    true,
+			wantSubstr: "max_cameras must be between 1 and 4",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCreateSessionRequest(tt.req)
+			if tt.wantErr {
+				assertInvalidArgument(t, err, tt.wantSubstr)
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// --- validateCloseSessionRequest ---
+
+func TestValidateCloseSessionRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		req        *pb.CloseSessionRequest
+		wantErr    bool
+		wantSubstr string
+	}{
+		{
+			name:    "valid request",
+			req:     &pb.CloseSessionRequest{RoomCode: "ROOM-000472", UserId: "director-1"},
+			wantErr: false,
+		},
+		{
+			name:       "empty room code",
+			req:        &pb.CloseSessionRequest{RoomCode: "", UserId: "director-1"},
+			wantErr:    true,
+			wantSubstr: "room_code is required",
+		},
+		{
+			name:       "malformed room code",
+			req:        &pb.CloseSessionRequest{RoomCode: "ROOM-ABC", UserId: "director-1"},
+			wantErr:    true,
+			wantSubstr: "room_code must match format ROOM-XXXXXX",
+		},
+		{
+			name:       "empty user id",
+			req:        &pb.CloseSessionRequest{RoomCode: "ROOM-000472", UserId: ""},
+			wantErr:    true,
+			wantSubstr: "user_id must be between 1 and 64 characters",
+		},
+		{
+			name:       "user id too long",
+			req:        &pb.CloseSessionRequest{RoomCode: "ROOM-000472", UserId: strings.Repeat("a", 65)},
+			wantErr:    true,
+			wantSubstr: "user_id must be between 1 and 64 characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateCloseSessionRequest(tt.req)
+			if tt.wantErr {
+				assertInvalidArgument(t, err, tt.wantSubstr)
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}
+
+// --- validateGetMySessionsRequest ---
+
+func TestValidateGetMySessionsRequest(t *testing.T) {
+	tests := []struct {
+		name    string
+		req     *pb.GetMySessionsRequest
+		wantErr bool
+	}{
+		{
+			name:    "valid request",
+			req:     &pb.GetMySessionsRequest{UserId: "director-1"},
+			wantErr: false,
+		},
+		{
+			name:    "empty user id",
+			req:     &pb.GetMySessionsRequest{UserId: ""},
+			wantErr: true,
+		},
+		{
+			name:    "user id too long",
+			req:     &pb.GetMySessionsRequest{UserId: strings.Repeat("a", 65)},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateGetMySessionsRequest(tt.req)
+			if tt.wantErr {
+				assertInvalidArgument(t, err, "user_id must be between 1 and 64 characters")
+			} else if err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Overview

Adds a dedicated validate.go file to the signaling package that centralises all input validation logic. Inline checks scattered across grpc.go are replaced with single validator calls at the top of each handler. Validation rules are now enforced consistently on every inbound RPC call, including those made directly via grpcurl or the Go test client, not just through the Qt UI.

### Changes

**New file — backend/internal/signaling/validate.go**
- Package-level constants: maxUserIDLength = 64, maxCamerasAllowed = 4
- Compiled regex: ^ROOM-\d{6}$ — initialised once at package load
- Shared helpers: validateRoomCode, validateUserID
- Per-RPC validators: validateJoinRequest, validateCreateSessionRequest, validateCloseSessionRequest, validateGetMySessionsRequest

**New file — backend/internal/signaling/validate_test.go**
- 30+ table-driven unit tests covering every validator
- Tests cases include: valid input, empty fields, malformed room codes, oversized user IDs, invalid roles, and out-of-range camera counts
- No server or Redis instance required — pure function tests

**Modified — backend/internal/signaling/grpc.go**
- Scattered inline validation blocks removed from all four handlers
- Each handler now opens with a single if err := validateXRequest(req); err != nil call
- No business logic changes

**Modified — backend/internal/signaling/grpc_test.go**
- Hardcoded room codes updated from ROOM-TEST to ROOM-123456 to satisfy the new regex

**Rules enforced**

- **Room code**: ROOM-\d{6}
- **User ID length**: 1 – 64 chars
- **Max cameras**: 1 – 4
- **Role**: camera | director

**Testing**

All existing tests pass.
Run:   `cd backend && make test-intergration`

Closes #210 
