### PR TITLE
fix: migrate video core and Whip publisher fixes

### DIFF
--- a/.github/workflows/video-core-ci.yml
+++ b/.github/workflows/video-core-ci.yml
@@ -46,7 +46,10 @@ jobs:
             libavutil-dev \
             libswscale-dev \
             libavdevice-dev \
-            libgtest-dev
+            libgtest-dev \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            libgstreamer-plugins-bad1.0-dev \
 
       - name: Build and run unit tests
         run: make test
@@ -103,7 +106,10 @@ jobs:
             libavformat-dev \
             libavutil-dev \
             libswscale-dev \
-            libavdevice-dev
+            libavdevice-dev \
+            libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
+            libgstreamer-plugins-bad1.0-dev
 
       - name: Generate compile_commands.json
         run: cmake -B build -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -143,7 +143,7 @@ target_include_directories(test_operator_session PRIVATE
     ${LIVEKIT_DIR}/include
     ${CMAKE_BINARY_DIR}
     ${GST_INCLUDE_DIRS}
-    ${FFMPEG_LIBRARIES}
+    ${FFMPEG_INCLUDE_DIRS}
     ${CMAKE_CURRENT_SOURCE_DIR}/../video-core/include
 )
 
@@ -196,6 +196,7 @@ target_link_libraries(test_livekit_room PRIVATE
     directlink_appplugin
     video_core
     fmt
+    Microsoft.GSL::GSL
 )
 
 target_link_libraries(test_operator_session PRIVATE

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -178,6 +178,7 @@ target_link_libraries(test_signaling_client PRIVATE
     signaling_proto
     signaling_grpc
     directlink_networkplugin
+    fmt
 )
 
 target_link_libraries(test_livekit_room PRIVATE
@@ -194,6 +195,7 @@ target_link_libraries(test_livekit_room PRIVATE
     directlink_networkplugin
     directlink_appplugin
     video_core
+    fmt
 )
 
 target_link_libraries(test_operator_session PRIVATE
@@ -211,6 +213,7 @@ target_link_libraries(test_operator_session PRIVATE
     directlink_networkplugin
     directlink_sessionplugin
     video_core
+    fmt
 )
 
 if(Qt6_VERSION VERSION_LESS 6.1.0)

--- a/networking/CMakeLists.txt
+++ b/networking/CMakeLists.txt
@@ -12,12 +12,20 @@ pkg_check_modules(GST REQUIRED
     gstreamer-video-1.0
 )
 
+pkg_check_modules(FFMPEG REQUIRED
+    libavcodec
+    libavformat
+    libavutil
+    libswscale
+)
+
 add_library(directlink_networking STATIC)
 
 target_include_directories(directlink_networking
     PUBLIC
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${GST_INCLUDE_DIRS}
+        ${FFMPEG_INCLUDE_DIRS}
 )
 
 target_link_libraries(directlink_networking

--- a/networking/include/whip_publisher.hpp
+++ b/networking/include/whip_publisher.hpp
@@ -26,12 +26,17 @@ public:
 
     void pushPacket(std::unique_ptr<videoCore::Packet> packet);
     [[nodiscard]] bool isRunning() const noexcept { return running_; }
-
+    
+    // Register a callback invoked when the remote decoder sends a RTCP PLI or
+    // FIR (via GstForceKeyUnitEvent).  The callback should request an IDR from
+    // the encoder.  Must be called before start().
     void setKeyframeRequestCallback(std::function<void()> cb) noexcept {
         forceKeyframeCallback_ = std::move(cb);
     }
 
 private:
+    void logBusError();
+
     std::string whipUrl_;
     std::string streamKey_;
     std::function<void(std::string)> onErrorCallback_;
@@ -42,5 +47,11 @@ private:
     std::mutex appsrcMutex_;
     std::uint64_t frameCount_ = 0;
     int framerate_ = 60; // Default framerate, can be overridden by config
+    
+    // Absolute PTS of the first packet pushed; used to compute pipeline-relative
+    // timestamps.  v4l2 timestamps are relative to device open, not the
+    // GStreamer pipeline base time, so raw PTS values would cause GStreamer to
+    // buffer packets until the pipeline clock catches up.
+    std::int64_t streamStartPts_ = -1;
 };
 } // namespace networking

--- a/networking/src/whip_publisher.cpp
+++ b/networking/src/whip_publisher.cpp
@@ -1,5 +1,6 @@
 #include "../include/whip_publisher.hpp"
 #include <cstring>
+#include <iostream>
 #include <gstreamer-1.0/gst/app/gstappsrc.h>
 #include <gstreamer-1.0/gst/gst.h>
 #include <gstreamer-1.0/gst/video/video.h>
@@ -51,27 +52,60 @@ WHIPPublisher::initialize(const std::string &whip_url,
     gst_caps_unref(caps);
 
     g_object_set(rtph264pay, "config-interval", 1, nullptr);
-    g_object_set(whipsink, "whip-endpoint", whipUrl_.c_str(), "auth-token",
-                 streamKey_.c_str(), nullptr);
+
+    // use-link-headers: LiveKit returns ICE servers in WHIP response Link
+    // headers. Without this, webrtcbin has no STUN/TURN and ICE fails silently.
+    // stun-server is a fallback if the server doesn't provide Link headers.
+    g_object_set(whipsink,
+                 "whip-endpoint", whipUrl_.c_str(),
+                 "auth-token", streamKey_.c_str(),
+                 "use-link-headers", TRUE,
+                 "stun-server", "stun://stun.l.google.com:19302",
+                 nullptr);
 
     gst_bin_add_many(GST_BIN(pipeline_), appsrc_, h264parse, rtph264pay,
                      whipsink, nullptr);
 
+    // Link appsrc -> h264parse -> rtph264pay normally
     if (!gst_element_link_many(appsrc_, h264parse, rtph264pay, nullptr)) {
+        std::cerr << "[WHIPPublisher] Failed to link appsrc -> h264parse -> rtph264pay\n";
         gst_element_set_state(pipeline_, GST_STATE_NULL);
         gst_object_unref(pipeline_);
         pipeline_ = nullptr;
         return Result::ErrorPipelineFailed;
     }
 
-    GstPad *src_pad = gst_element_get_static_pad(rtph264pay, "src");
-    GstPad *sink_pad = gst_element_request_pad_simple(whipsink, "sink_0");
+    // whipsink wraps webrtcbin internally; webrtcbin requires explicit caps
+    // when requesting a sink pad — gst_element_link won't work without them.
+    GstCaps *rtp_caps = gst_caps_new_simple(
+        "application/x-rtp",
+        "media", G_TYPE_STRING, "video",
+        "encoding-name", G_TYPE_STRING, "H264",
+        "payload", G_TYPE_INT, 96,
+        "clock-rate", G_TYPE_INT, 90000,
+        nullptr);
+    GstPadTemplate *templ = gst_element_class_get_pad_template(
+        GST_ELEMENT_GET_CLASS(whipsink), "sink_%u");
+    GstPad *whip_sink_pad =
+        gst_element_request_pad(whipsink, templ, nullptr, rtp_caps);
+    gst_caps_unref(rtp_caps);
 
-    GstPadLinkReturn ret = gst_pad_link(src_pad, sink_pad);
-    gst_object_unref(src_pad);
-    gst_object_unref(sink_pad);
+    if (whip_sink_pad == nullptr) {
+        std::cerr << "[WHIPPublisher] Failed to request pad from whipsink\n";
+        gst_element_set_state(pipeline_, GST_STATE_NULL);
+        gst_object_unref(pipeline_);
+        pipeline_ = nullptr;
+        return Result::ErrorPipelineFailed;
+    }
 
-    if (ret != GST_PAD_LINK_OK) {
+    GstPad *pay_src_pad = gst_element_get_static_pad(rtph264pay, "src");
+    GstPadLinkReturn link_ret = gst_pad_link(pay_src_pad, whip_sink_pad);
+    gst_object_unref(pay_src_pad);
+    gst_object_unref(whip_sink_pad);
+
+    if (link_ret != GST_PAD_LINK_OK) {
+        std::cerr << "[WHIPPublisher] Failed to link rtph264pay -> whipsink: "
+                  << link_ret << "\n";
         gst_element_set_state(pipeline_, GST_STATE_NULL);
         gst_object_unref(pipeline_);
         pipeline_ = nullptr;
@@ -97,14 +131,18 @@ WHIPPublisher::initialize(const std::string &whip_url,
         this);
     gst_object_unref(bus);
 
-    
+    // Intercept GstForceKeyUnitEvent travelling upstream from webrtcbin (inside
+    // whipsink) when the remote decoder sends an RTCP PLI or FIR.  Calling
+    // forceKeyframeCallback_ asks the encoder to emit an IDR on the next frame
+    // so the decoder can recover immediately rather than waiting for the next
+    // scheduled GOP boundary.
     GstPad *appsrc_src = gst_element_get_static_pad(appsrc_, "src");
     gst_pad_add_probe(appsrc_src,
         GST_PAD_PROBE_TYPE_EVENT_UPSTREAM,
         [](GstPad *, GstPadProbeInfo *info, gpointer data) -> GstPadProbeReturn {
             auto *self = static_cast<WHIPPublisher *>(data);
             GstEvent *event = GST_PAD_PROBE_INFO_EVENT(info);
-            if ((gst_video_event_is_force_key_unit(event) != 0) &&
+            if (gst_video_event_is_force_key_unit(event) &&
                     self->forceKeyframeCallback_) {
                 self->forceKeyframeCallback_();
             }
@@ -114,6 +152,36 @@ WHIPPublisher::initialize(const std::string &whip_url,
     gst_object_unref(appsrc_src);
 
     return Result::Success;
+}
+
+void WHIPPublisher::logBusError() {
+    if (pipeline_ == nullptr) {
+        return;
+    }
+    GstBus *bus = gst_element_get_bus(pipeline_);
+    GstMessage *msg =
+        gst_bus_timed_pop_filtered(bus, 0, static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_WARNING));
+        
+    while (msg != nullptr) {
+        GError *err = nullptr;
+        gchar *debug_info = nullptr;
+        if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_ERROR) {
+            gst_message_parse_error(msg, &err, &debug_info);
+            std::cerr << "[WHIPPublisher] GStreamer error: " << err->message << "\n";
+        } else {
+            gst_message_parse_warning(msg, &err, &debug_info);
+            std::cerr << "[WHIPPublisher] GStreamer warning: " << err->message << "\n";
+        }
+        if (debug_info) {
+            std::cerr << "[WHIPPublisher] Debug: " << debug_info << "\n";
+        }
+        g_clear_error(&err);
+        g_free(debug_info);
+        gst_message_unref(msg);
+        msg = gst_bus_timed_pop_filtered(bus, 0,
+                                         static_cast<GstMessageType>(GST_MESSAGE_ERROR | GST_MESSAGE_WARNING));
+    }
+    gst_object_unref(bus);
 }
 
 Result WHIPPublisher::start() {
@@ -128,16 +196,23 @@ Result WHIPPublisher::start() {
     GstStateChangeReturn ret =
         gst_element_set_state(pipeline_, GST_STATE_PLAYING);
     if (ret == GST_STATE_CHANGE_FAILURE) {
+        logBusError();
         return Result::ErrorPipelineFailed;
     }
 
-    // Wait up to 5 seconds for the async WHIP handshake to complete
-    // This blocks the calling thread
+    // Wait up to 20 seconds — whipsink default WHIP timeout is 15s
     if (ret == GST_STATE_CHANGE_ASYNC) {
         GstState state;
         GstStateChangeReturn waited =
-            gst_element_get_state(pipeline_, &state, nullptr, 5 * GST_SECOND);
+            gst_element_get_state(pipeline_, &state, nullptr, 20 * GST_SECOND);
+
         if (waited == GST_STATE_CHANGE_FAILURE) {
+            logBusError();
+            gst_element_set_state(pipeline_, GST_STATE_NULL);
+            return Result::ErrorPipelineFailed;
+        }
+        if (waited == GST_STATE_CHANGE_ASYNC) {
+            std::cerr << "[WHIPPublisher] Timed out waiting for WHIP handshake\n";
             gst_element_set_state(pipeline_, GST_STATE_NULL);
             return Result::ErrorPipelineFailed;
         }
@@ -165,20 +240,18 @@ Result WHIPPublisher::stop() {
         gst_app_src_end_of_stream(GST_APP_SRC(appsrc_));
     }
 
-    // Wait for EOS to propagate through the pipeline, 3 second timeout
+    // Wait for EOS to propagate — whipsink sends an HTTP DELETE to the WHIP
+    // server on EOS, which can take a few seconds on a remote endpoint.
     GstBus *bus = gst_element_get_bus(pipeline_);
     GstMessage *msg =
-        gst_bus_timed_pop_filtered(bus, 3 * GST_SECOND, GST_MESSAGE_EOS);
+        gst_bus_timed_pop_filtered(bus, 10 * GST_SECOND, GST_MESSAGE_EOS);
     gst_object_unref(bus);
 
     if (msg != nullptr) {
         gst_message_unref(msg);
     }
     else {
-        if (onErrorCallback_) {
-            onErrorCallback_(
-                "Timeout waiting for EOS message from GStreamer pipeline");
-        }
+        std::cerr << "[WHIPPublisher] EOS drain timed out; forcing pipeline to NULL\n";
     }
 
     GstBus *bus2 = gst_element_get_bus(pipeline_);
@@ -189,6 +262,7 @@ Result WHIPPublisher::stop() {
     pipeline_ = nullptr;
     appsrc_ = nullptr;
     running_ = false;
+    streamStartPts_ = -1;
     return Result::Success;
 }
 
@@ -206,7 +280,17 @@ void WHIPPublisher::pushPacket(std::unique_ptr<videoCore::Packet> packet) {
     std::memcpy(map.data, av->data, av->size);
     gst_buffer_unmap(buffer, &map);
 
-    GST_BUFFER_PTS(buffer) = static_cast<GstClockTime>(packet->pts);
+    // Normalize to pipeline-relative time.  v4l2 timestamps are absolute
+    // (from device open), not relative to the GStreamer pipeline base time.
+    // Passing the raw PTS would cause GStreamer to hold every buffer until
+    // the pipeline clock reaches that timestamp, introducing a ~16-second
+    // scheduling delay before any data reaches the ingress.
+    if (streamStartPts_ < 0) {
+        streamStartPts_ = packet->pts;
+    }
+    GstClockTime relativePts =
+        static_cast<GstClockTime>(packet->pts - streamStartPts_);
+    GST_BUFFER_PTS(buffer) = relativePts;
     if (framerate_ == 0) {
         framerate_ = 30; // Fallback to default if framerate is zero to avoid
                          // division by zero

--- a/video-core/CMakeLists.txt
+++ b/video-core/CMakeLists.txt
@@ -19,6 +19,13 @@ pkg_check_modules(FFMPEG REQUIRED
     libavdevice
 )
 
+# GStreamer — used by camera_capture for PipeWire-native capture
+pkg_check_modules(GST REQUIRED
+    gstreamer-1.0
+    gstreamer-app-1.0
+    gstreamer-video-1.0
+)
+
 # Compiler flags
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -O0")
@@ -41,10 +48,12 @@ add_library(video_core STATIC
 target_include_directories(video_core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${FFMPEG_INCLUDE_DIRS}
+    ${GST_INCLUDE_DIRS}
 )
 
 target_link_libraries(video_core PUBLIC
     ${FFMPEG_LIBRARIES}
+    ${GST_LIBRARIES}
 )
 
 # =================================================================

--- a/video-core/CMakeLists.txt
+++ b/video-core/CMakeLists.txt
@@ -16,7 +16,6 @@ pkg_check_modules(FFMPEG REQUIRED
     libavformat
     libavutil
     libswscale
-    libavdevice
 )
 
 # GStreamer — used by camera_capture for PipeWire-native capture

--- a/video-core/Makefile
+++ b/video-core/Makefile
@@ -3,6 +3,7 @@
 CXX := g++
 CXXFLAGS := -std=c++20 -Wall -Wextra -Wpedantic -g -fno-omit-frame-pointer
 LDFLAGS := $(shell pkg-config --libs libavcodec libavformat libavutil libswscale libavdevice)
+GST_FLAGS := $(shell pkg-config --cflags --libs gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0)
 INCLUDES := -Iinclude $(shell pkg-config --cflags libavcodec libavformat libavutil libswscale libavdevice)
 
 # Directories
@@ -121,7 +122,7 @@ test: $(UNIT_TEST_BIN)
 	@$(UNIT_TEST_BIN)
 
 $(UNIT_TEST_BIN): $(UNIT_TEST_SRC) | $(BIN_DIR)
-	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS) $(GTEST_FLAGS)
+	$(CXX) $(CXXFLAGS) $(INCLUDES) $^ -o $@ $(LDFLAGS) $(GTEST_FLAGS) $(GST_FLAGS)
 	@echo "Built unit tests -> $@"
 
 PIPELINE_TEST_SRC := tests/integration/test_video_pipeline.cpp \

--- a/video-core/Makefile
+++ b/video-core/Makefile
@@ -37,13 +37,17 @@ all: tests
 tests: encode_test nvenc_test
 
 LINT_DIRS := src include tests/unit tests/integration
+GST_CFLAGS := $(shell pkg-config --cflags gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0)
 
 # Lint code with clang-tidy
 lint:
 	@echo "Running clang-tidy on source files..."
 	@find $(LINT_DIRS) -name "*.cpp" | \
         xargs -P$(shell nproc) -I{} clang-tidy -p $(BUILD_DIR) \
-        --extra-arg=-std=c++20 {}
+        --extra-arg=-std=c++20 \
+        --header-filter='.*direct-link/video-core/.*' \
+        $(addprefix --extra-arg=,$(GST_CFLAGS)) \
+        {}
 	@echo "Lint complete!"
 
 # Format source code (fixes files in place - run locally)

--- a/video-core/Makefile
+++ b/video-core/Makefile
@@ -2,9 +2,9 @@
 
 CXX := g++
 CXXFLAGS := -std=c++20 -Wall -Wextra -Wpedantic -g -fno-omit-frame-pointer
-LDFLAGS := $(shell pkg-config --libs libavcodec libavformat libavutil libswscale libavdevice)
+LDFLAGS := $(shell pkg-config --libs libavcodec libavformat libavutil libswscale)
 GST_FLAGS := $(shell pkg-config --cflags --libs gstreamer-1.0 gstreamer-app-1.0 gstreamer-video-1.0)
-INCLUDES := -Iinclude $(shell pkg-config --cflags libavcodec libavformat libavutil libswscale libavdevice)
+INCLUDES := -Iinclude $(shell pkg-config --cflags libavcodec libavformat libavutil libswscale)
 
 # Directories
 BUILD_DIR := build

--- a/video-core/include/capture/camera_capture.hpp
+++ b/video-core/include/capture/camera_capture.hpp
@@ -23,7 +23,9 @@ public:
     Result start(std::function<void(std::unique_ptr<Frame>)> frameCallback);
     Result stop();
 
-    [[nodiscard]] bool isRunning() const { return running_.load(std::memory_order_relaxed); }
+    [[nodiscard]] bool isRunning() const {
+        return running_.load(std::memory_order_relaxed);
+    }
     [[nodiscard]] int getWidth() const { return width_; }
     [[nodiscard]] int getHeight() const { return height_; }
     [[nodiscard]] int getFramerate() const { return framerate_; }
@@ -31,13 +33,13 @@ public:
 private:
     CaptureConfig config_;
     GstElement *pipeline_ = nullptr;
-    GstElement *appsink_  = nullptr;
+    GstElement *appsink_ = nullptr;
 
     std::atomic<bool> running_{false};
     std::jthread captureThread_;
 
-    int width_     = 0;
-    int height_    = 0;
+    int width_ = 0;
+    int height_ = 0;
     int framerate_ = 0;
 
     std::function<void(std::unique_ptr<Frame>)> frameCallback_;

--- a/video-core/include/capture/camera_capture.hpp
+++ b/video-core/include/capture/camera_capture.hpp
@@ -6,7 +6,7 @@
 #include <functional>
 #include <thread>
 
-typedef struct _GstElement GstElement;  // NOLINT(modernize-use-using, bugprone-reserved-identifier)
+#include <gst/gst.h>
 namespace videoCore::capture {
 
 class CameraCapture {

--- a/video-core/include/capture/camera_capture.hpp
+++ b/video-core/include/capture/camera_capture.hpp
@@ -2,20 +2,20 @@
 
 #include "../common/types.hpp"
 #include "capture_config.hpp"
+#include <atomic>
 #include <functional>
 #include <thread>
 
-struct AVFormatContext;
-struct AVCodecContext;
+#include <gst/gst.h>
 
 namespace videoCore::capture {
+
 class CameraCapture {
 public:
     CameraCapture() = default;
     ~CameraCapture();
     CameraCapture(CameraCapture &&) = delete;
     CameraCapture &operator=(CameraCapture &&) = delete;
-
     CameraCapture(const CameraCapture &) = delete;
     CameraCapture &operator=(const CameraCapture &) = delete;
 
@@ -23,25 +23,27 @@ public:
     Result start(std::function<void(std::unique_ptr<Frame>)> frameCallback);
     Result stop();
 
-    [[nodiscard]] bool isRunning() const { return captureThread_.joinable(); }
-    [[nodiscard]] int getWidth() const;
-    [[nodiscard]] int getHeight() const;
-    [[nodiscard]] int getFramerate() const;
+    [[nodiscard]] bool isRunning() const { return running_.load(std::memory_order_relaxed); }
+    [[nodiscard]] int getWidth() const { return width_; }
+    [[nodiscard]] int getHeight() const { return height_; }
+    [[nodiscard]] int getFramerate() const { return framerate_; }
 
 private:
     CaptureConfig config_;
-    AVFormatContext *formatCtx_ = nullptr;
-    AVCodecContext *codecCtx_ = nullptr;
-    int videoStreamIdx_ = -1;
+    GstElement *pipeline_ = nullptr;
+    GstElement *appsink_  = nullptr;
+
+    std::atomic<bool> running_{false};
     std::jthread captureThread_;
+
+    int width_     = 0;
+    int height_    = 0;
+    int framerate_ = 0;
 
     std::function<void(std::unique_ptr<Frame>)> frameCallback_;
 
+    [[nodiscard]] Result buildPipeline();
     void captureLoop(const std::stop_token &stopToken);
-    Result setupDevice();
-    Result setupCodec();
-
-    bool processPacket(AVPacket *packet, AVFrame *frame);
-    bool processFrame(AVFrame *frame);
 };
+
 } // namespace videoCore::capture

--- a/video-core/include/capture/camera_capture.hpp
+++ b/video-core/include/capture/camera_capture.hpp
@@ -6,8 +6,7 @@
 #include <functional>
 #include <thread>
 
-using GstElement = struct GstElement;
-
+typedef struct _GstElement GstElement;  // NOLINT(modernize-use-using, bugprone-reserved-identifier)
 namespace videoCore::capture {
 
 class CameraCapture {

--- a/video-core/include/capture/camera_capture.hpp
+++ b/video-core/include/capture/camera_capture.hpp
@@ -6,7 +6,7 @@
 #include <functional>
 #include <thread>
 
-#include <gst/gst.h>
+using GstElement = struct GstElement;
 
 namespace videoCore::capture {
 

--- a/video-core/include/encode/encoder.hpp
+++ b/video-core/include/encode/encoder.hpp
@@ -20,7 +20,8 @@ public:
                std::function<void(std::unique_ptr<Packet>)> packetCallback);
     [[nodiscard]] virtual Result encodeFrame(AVFrame *frame) = 0;
     virtual void stop() = 0;
-    // Requests an IDR (instantaneous decoder refresh) to allow remote decoder to recover after packet loss
+    // Requests an IDR (instantaneous decoder refresh) to allow remote decoder
+    // to recover after packet loss
     virtual void requestKeyframe() noexcept {}
 
     [[nodiscard]] virtual bool isRunning() const { return running_; };

--- a/video-core/src/capture/camera_capture.cpp
+++ b/video-core/src/capture/camera_capture.cpp
@@ -57,12 +57,12 @@ Result CameraCapture::buildPipeline() {
     const int f = config_.framerate;
     const std::string dev = config_.devicePath;
 
-    const std::string rawCaps = "video/x-raw,format=I420"
+    const std::string raw_caps = "video/x-raw,format=I420"
                                 ",width=" +
                                 std::to_string(w) +
                                 ",height=" + std::to_string(h) +
                                 ",framerate=" + std::to_string(f) + "/1";
-    const std::string sinkProps = "appsink name=sink sync=false max-buffers=4 "
+    const std::string sink_props = "appsink name=sink sync=false max-buffers=4 "
                                   "drop=true emit-signals=false";
 
     // Ordered candidates. Each is probed to READY state; the first that
@@ -87,7 +87,7 @@ Result CameraCapture::buildPipeline() {
         ",height=" + std::to_string(h) + ",framerate=" + std::to_string(f) +
         "/1"
         " ! jpegdec ! videoconvert ! video/x-raw,format=I420 ! " +
-        sinkProps);
+        sink_props);
 
     // V4L2 raw — fallback for cameras without MJPEG.
     candidates.push_back(
@@ -95,25 +95,25 @@ Result CameraCapture::buildPipeline() {
         ",height=" + std::to_string(h) + ",framerate=" + std::to_string(f) +
         "/1"
         " ! videoconvert ! video/x-raw,format=I420 ! " +
-        sinkProps);
+        sink_props);
 
-    GstElementFactory *pwFactory = gst_element_factory_find("pipewiresrc");
-    if (pwFactory != nullptr) {
-        gst_object_unref(pwFactory);
+    GstElementFactory *pw_factory = gst_element_factory_find("pipewiresrc");
+    if (pw_factory != nullptr) {
+        gst_object_unref(pw_factory);
         candidates.push_back("pipewiresrc target-object=" + dev +
                              " do-timestamp=true"
                              " ! jpegdec ! videoconvert ! videoscale ! " +
-                             rawCaps + " ! " + sinkProps);
+                             raw_caps + " ! " + sink_props);
         candidates.push_back("pipewiresrc do-timestamp=true"
                              " ! jpegdec ! videoconvert ! videoscale ! " +
-                             rawCaps + " ! " + sinkProps);
+                             raw_caps + " ! " + sink_props);
         candidates.push_back("pipewiresrc target-object=" + dev +
                              " do-timestamp=true"
                              " ! videoconvert ! videoscale ! " +
-                             rawCaps + " ! " + sinkProps);
+                             raw_caps + " ! " + sink_props);
         candidates.push_back("pipewiresrc do-timestamp=true"
                              " ! videoconvert ! videoscale ! " +
-                             rawCaps + " ! " + sinkProps);
+                             raw_caps + " ! " + sink_props);
     }
 
     for (const auto &pipelineStr : candidates) {
@@ -294,11 +294,11 @@ Result CameraCapture::stop() {
 
 void CameraCapture::captureLoop(const std::stop_token &stopToken) {
     // 100 ms pull timeout expressed in nanoseconds.
-    constexpr GstClockTime kPullTimeoutNs = 100 * GST_MSECOND;
+    constexpr GstClockTime k_pull_timeout_ns = 100 * GST_MSECOND;
 
     while (!stopToken.stop_requested()) {
         GstSample *sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appsink_),
-                                                         kPullTimeoutNs);
+                                                         k_pull_timeout_ns);
 
         if (sample == nullptr) {
             // Timeout or EOS — check the bus for a hard error before looping.
@@ -377,26 +377,26 @@ void CameraCapture::captureLoop(const std::stop_token &stopToken) {
         // Copy the three YUV planes row-by-row, guarding against stride
         // mismatches.
         for (int plane = 0; plane < 3; ++plane) {
-            const int srcStride = GST_VIDEO_FRAME_PLANE_STRIDE(&vframe, plane);
-            const int dstStride = avf->linesize[plane];
-            const int planeHeight =
+            const int src_stride = GST_VIDEO_FRAME_PLANE_STRIDE(&vframe, plane);
+            const int dst_stride = avf->linesize[plane];
+            const int plane_height =
                 (plane == 0) ? avf->height : (avf->height + 1) / 2;
-            const int copyWidth = std::min(srcStride, dstStride);
+            const int copy_width = std::min(src_stride, dst_stride);
 
             const auto *src = static_cast<const uint8_t *>(
                 GST_VIDEO_FRAME_PLANE_DATA(&vframe, plane));
             uint8_t *dst = avf->data[plane];
 
-            for (int row = 0; row < planeHeight; ++row) {
-                std::memcpy(dst + row * dstStride, src + row * srcStride,
-                            static_cast<std::size_t>(copyWidth));
+            for (int row = 0; row < plane_height; ++row) {
+                std::memcpy(dst + row * dst_stride, src + row * src_stride,
+                            static_cast<std::size_t>(copy_width));
             }
         }
 
         // PTS from the GStreamer buffer, in nanoseconds.
-        GstClockTime bufPts = GST_BUFFER_PTS(buffer);
+        GstClockTime buf_pts = GST_BUFFER_PTS(buffer);
         avf->pts =
-            GST_CLOCK_TIME_IS_VALID(bufPts) ? static_cast<int64_t>(bufPts) : 0;
+            GST_CLOCK_TIME_IS_VALID(buf_pts) ? static_cast<int64_t>(buf_pts) : 0;
 
         gst_video_frame_unmap(&vframe);
         gst_sample_unref(sample);

--- a/video-core/src/capture/camera_capture.cpp
+++ b/video-core/src/capture/camera_capture.cpp
@@ -178,7 +178,7 @@ Result CameraCapture::buildPipeline() {
                 gst_message_parse_error(msg, &busErr, &dbg);
                 std::cerr << "[CameraCapture] error: "
                           << (busErr != nullptr ? busErr->message : "?");
-                
+
                 if (dbg != nullptr) {
                     std::cerr << " | " << dbg;
                 }

--- a/video-core/src/capture/camera_capture.cpp
+++ b/video-core/src/capture/camera_capture.cpp
@@ -12,7 +12,11 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 }
 
-// NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast, bugprone-casting-through-void, cppcoreguidelines-pro-bounds-constant-array-index, clang-analyzer-optin.core.EnumCastOutOfRange, readability-implicit-bool-conversion)
+// NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast,
+// bugprone-casting-through-void,
+// cppcoreguidelines-pro-bounds-constant-array-index,
+// clang-analyzer-optin.core.EnumCastOutOfRange,
+// readability-implicit-bool-conversion)
 namespace videoCore::capture {
 
 CameraCapture::~CameraCapture() {
@@ -59,12 +63,12 @@ Result CameraCapture::buildPipeline() {
     const std::string dev = config_.devicePath;
 
     const std::string raw_caps = "video/x-raw,format=I420"
-                                ",width=" +
-                                std::to_string(w) +
-                                ",height=" + std::to_string(h) +
-                                ",framerate=" + std::to_string(f) + "/1";
+                                 ",width=" +
+                                 std::to_string(w) +
+                                 ",height=" + std::to_string(h) +
+                                 ",framerate=" + std::to_string(f) + "/1";
     const std::string sink_props = "appsink name=sink sync=false max-buffers=4 "
-                                  "drop=true emit-signals=false";
+                                   "drop=true emit-signals=false";
 
     // Ordered candidates. Each is probed to READY state; the first that
     // succeeds is kept. READY is sufficient to check device availability — it
@@ -121,11 +125,12 @@ Result CameraCapture::buildPipeline() {
         std::cerr << "[CameraCapture] trying: " << pipeline_str << "\n";
 
         GError *parse_err = nullptr;
-        GstElement *pipeline = gst_parse_launch(pipeline_str.c_str(), &parse_err);
+        GstElement *pipeline =
+            gst_parse_launch(pipeline_str.c_str(), &parse_err);
         if (parse_err != nullptr || pipeline == nullptr) {
             std::cerr << "[CameraCapture] parse error: "
                       << (parse_err != nullptr ? parse_err->message
-                                              : "null pipeline")
+                                               : "null pipeline")
                       << "\n";
             if (parse_err != nullptr) {
                 g_error_free(parse_err);
@@ -388,15 +393,17 @@ void CameraCapture::captureLoop(const std::stop_token &stopToken) {
             uint8_t *dst = avf->data[plane];
 
             for (int row = 0; row < plane_height; ++row) {
-                std::memcpy(dst + (static_cast<ptrdiff_t>(row) * dst_stride), src + (static_cast<ptrdiff_t>(row) * src_stride),
+                std::memcpy(dst + (static_cast<ptrdiff_t>(row) * dst_stride),
+                            src + (static_cast<ptrdiff_t>(row) * src_stride),
                             static_cast<std::size_t>(copy_width));
             }
         }
 
         // PTS from the GStreamer buffer, in nanoseconds.
         GstClockTime buf_pts = GST_BUFFER_PTS(buffer);
-        avf->pts =
-            GST_CLOCK_TIME_IS_VALID(buf_pts) ? static_cast<int64_t>(buf_pts) : 0;
+        avf->pts = GST_CLOCK_TIME_IS_VALID(buf_pts)
+                       ? static_cast<int64_t>(buf_pts)
+                       : 0;
 
         gst_video_frame_unmap(&vframe);
         gst_sample_unref(sample);
@@ -417,4 +424,8 @@ void CameraCapture::captureLoop(const std::stop_token &stopToken) {
 }
 
 } // namespace videoCore::capture
-// NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast, bugprone-casting-through-void, cppcoreguidelines-pro-bounds-constant-array-index, clang-analyzer-optin.core.EnumCastOutOfRange, readability-implicit-bool-conversion)
+// NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast,
+// bugprone-casting-through-void,
+// cppcoreguidelines-pro-bounds-constant-array-index,
+// clang-analyzer-optin.core.EnumCastOutOfRange,
+// readability-implicit-bool-conversion)

--- a/video-core/src/capture/camera_capture.cpp
+++ b/video-core/src/capture/camera_capture.cpp
@@ -1,212 +1,419 @@
 #include "../../include/capture/camera_capture.hpp"
 #include "../../include/capture/capture_config.hpp"
-#include <chrono>
-#include <functional>
-#include <thread>
+#include <cstring>
+#include <gst/app/gstappsink.h>
+#include <gst/gst.h>
+#include <gst/video/video.h>
+#include <iostream>
+#include <string>
 
 extern "C" {
-#include <libavcodec/avcodec.h>
-#include <libavdevice/avdevice.h>
-#include <libavformat/avformat.h>
+#include <libavutil/frame.h>
+#include <libavutil/pixfmt.h>
 }
 
 namespace videoCore::capture {
+
 CameraCapture::~CameraCapture() {
     stop();
-
-    if (codecCtx_ != nullptr) {
-        avcodec_free_context(&codecCtx_);
-        codecCtx_ = nullptr;
+    if (appsink_ != nullptr) {
+        gst_object_unref(appsink_);
+        appsink_ = nullptr;
     }
-    if (formatCtx_ != nullptr) {
-        avformat_close_input(&formatCtx_);
-        formatCtx_ = nullptr;
+    if (pipeline_ != nullptr) {
+        // Always transition to NULL before unreffing. If start() never ran (or
+        // failed mid-way), the pipeline may still own live GStreamer threads
+        // that would keep the process alive after the window is closed.
+        gst_element_set_state(pipeline_, GST_STATE_NULL);
+        gst_object_unref(pipeline_);
+        pipeline_ = nullptr;
     }
 }
 
 Result CameraCapture::initialize(const CaptureConfig &config) {
     config_ = config;
 
-    auto res = setupDevice();
-    if (res != Result::Success) {
-        return res;
+    // Apply defaults for unspecified dimensions/framerate.
+    if (config_.width == 0) {
+        config_.width = 1280;
+    }
+    if (config_.height == 0) {
+        config_.height = 720;
+    }
+    if (config_.framerate == 0) {
+        config_.framerate = 30;
     }
 
-    res = setupCodec();
-    if (res != Result::Success) {
-        return res;
+    if (!gst_is_initialized()) {
+        gst_init(nullptr, nullptr);
     }
 
-    return Result::Success;
+    return buildPipeline();
+}
+
+Result CameraCapture::buildPipeline() {
+    const int w = config_.width;
+    const int h = config_.height;
+    const int f = config_.framerate;
+    const std::string dev = config_.devicePath;
+
+    const std::string rawCaps = "video/x-raw,format=I420"
+                                ",width=" +
+                                std::to_string(w) +
+                                ",height=" + std::to_string(h) +
+                                ",framerate=" + std::to_string(f) + "/1";
+    const std::string sinkProps = "appsink name=sink sync=false max-buffers=4 "
+                                  "drop=true emit-signals=false";
+
+    // Ordered candidates. Each is probed to READY state; the first that
+    // succeeds is kept. READY is sufficient to check device availability — it
+    // avoids the cleanup hang caused by stopping a live streaming thread
+    // mid-flight.
+    //
+    // Candidate ordering rationale:
+    //  - v4l2src comes first: it is universally compatible and works whether
+    //    PipeWire is present or absent (via the pipewire-v4l2 compat layer).
+    //    pipewiresrc requires the session manager (WirePlumber) to have
+    //    registered video nodes; when no nodes exist it hangs indefinitely at
+    //    PLAYING.
+    //  - pipewiresrc variants are kept as fallbacks for environments where
+    //  native
+    //    PipeWire video nodes are available and v4l2 compat is disabled.
+    std::vector<std::string> candidates;
+
+    // V4L2 MJPEG — preferred; most USB cameras expose MJPEG at 720p+/30fps.
+    candidates.push_back(
+        "v4l2src device=" + dev + " ! image/jpeg,width=" + std::to_string(w) +
+        ",height=" + std::to_string(h) + ",framerate=" + std::to_string(f) +
+        "/1"
+        " ! jpegdec ! videoconvert ! video/x-raw,format=I420 ! " +
+        sinkProps);
+
+    // V4L2 raw — fallback for cameras without MJPEG.
+    candidates.push_back(
+        "v4l2src device=" + dev + " ! video/x-raw,width=" + std::to_string(w) +
+        ",height=" + std::to_string(h) + ",framerate=" + std::to_string(f) +
+        "/1"
+        " ! videoconvert ! video/x-raw,format=I420 ! " +
+        sinkProps);
+
+    GstElementFactory *pwFactory = gst_element_factory_find("pipewiresrc");
+    if (pwFactory != nullptr) {
+        gst_object_unref(pwFactory);
+        candidates.push_back("pipewiresrc target-object=" + dev +
+                             " do-timestamp=true"
+                             " ! jpegdec ! videoconvert ! videoscale ! " +
+                             rawCaps + " ! " + sinkProps);
+        candidates.push_back("pipewiresrc do-timestamp=true"
+                             " ! jpegdec ! videoconvert ! videoscale ! " +
+                             rawCaps + " ! " + sinkProps);
+        candidates.push_back("pipewiresrc target-object=" + dev +
+                             " do-timestamp=true"
+                             " ! videoconvert ! videoscale ! " +
+                             rawCaps + " ! " + sinkProps);
+        candidates.push_back("pipewiresrc do-timestamp=true"
+                             " ! videoconvert ! videoscale ! " +
+                             rawCaps + " ! " + sinkProps);
+    }
+
+    for (const auto &pipelineStr : candidates) {
+        std::cerr << "[CameraCapture] trying: " << pipelineStr << "\n";
+
+        GError *parseErr = nullptr;
+        GstElement *pipeline = gst_parse_launch(pipelineStr.c_str(), &parseErr);
+        if (parseErr != nullptr || pipeline == nullptr) {
+            std::cerr << "[CameraCapture] parse error: "
+                      << (parseErr != nullptr ? parseErr->message
+                                              : "null pipeline")
+                      << "\n";
+            if (parseErr != nullptr) {
+                g_error_free(parseErr);
+            }
+            if (pipeline != nullptr) {
+                gst_object_unref(pipeline);
+            }
+            continue;
+        }
+
+        // Probe to READY — this allocates device resources without starting the
+        // streaming thread. PLAYING validation is deferred to start() so that
+        // we never need to tear down a live source mid-flight during candidate
+        // probing, which can cause pipewiresrc to hang on cleanup.
+        GstStateChangeReturn ret =
+            gst_element_set_state(pipeline, GST_STATE_READY);
+        GstState reached = GST_STATE_NULL;
+        if (ret != GST_STATE_CHANGE_FAILURE) {
+            ret =
+                gst_element_get_state(pipeline, &reached, nullptr, GST_SECOND);
+        }
+
+        if (ret != GST_STATE_CHANGE_FAILURE && reached == GST_STATE_READY) {
+            GstElement *appsink =
+                gst_bin_get_by_name(GST_BIN(pipeline), "sink");
+            if (appsink != nullptr) {
+                pipeline_ = pipeline;
+                appsink_ = appsink;
+                width_ = w;
+                height_ = h;
+                framerate_ = f;
+                std::cerr << "[CameraCapture] pipeline ready\n";
+                return Result::Success;
+            }
+            // appsink was null — pipeline built but sink not found
+            std::cerr
+                << "[CameraCapture] appsink element not found in pipeline\n";
+            gst_element_set_state(pipeline, GST_STATE_NULL);
+            gst_object_unref(pipeline);
+        }
+
+        // Candidate failed — drain the bus for a diagnostic message then move
+        // on.
+        GstBus *bus = gst_element_get_bus(pipeline);
+        if (bus != nullptr) {
+            GstMessage *msg = gst_bus_timed_pop_filtered(bus, 500 * GST_MSECOND,
+                                                         GST_MESSAGE_ERROR);
+            if (msg != nullptr) {
+                GError *busErr = nullptr;
+                gchar *dbg = nullptr;
+                gst_message_parse_error(msg, &busErr, &dbg);
+                std::cerr << "[CameraCapture] error: "
+                          << (busErr != nullptr ? busErr->message : "?");
+                
+                if (dbg != nullptr) {
+                    std::cerr << " | " << dbg;
+                }
+                std::cerr << "\n";
+                if (busErr != nullptr) {
+                    g_error_free(busErr);
+                }
+                if (dbg != nullptr) {
+                    g_free(dbg);
+                }
+                gst_message_unref(msg);
+            }
+            gst_object_unref(bus);
+        }
+        gst_element_set_state(pipeline, GST_STATE_NULL);
+        gst_object_unref(pipeline);
+    }
+
+    std::cerr << "[CameraCapture] all pipeline candidates failed\n";
+    return Result::ErrorDeviceNotFound;
+}
+
+// Drain the GStreamer bus and log the first ERROR message, if any.
+// Uses a 500 ms timed wait because pipewiresrc posts its error asynchronously —
+// a non-blocking pop races with the message delivery and silently misses it.
+static void logPipelineError(GstElement *pipeline) {
+    GstBus *bus = gst_element_get_bus(pipeline);
+    if (bus == nullptr) {
+        return;
+    }
+    GstMessage *msg =
+        gst_bus_timed_pop_filtered(bus, 500 * GST_MSECOND, GST_MESSAGE_ERROR);
+    if (msg != nullptr) {
+        GError *err = nullptr;
+        gchar *dbg = nullptr;
+
+        gst_message_parse_error(msg, &err, &dbg);
+        std::cerr << "[CameraCapture] pipeline error: "
+                  << (err != nullptr ? err->message : "?");
+        if (dbg != nullptr) {
+            std::cerr << " | " << dbg;
+        }
+        std::cerr << "\n";
+        if (err != nullptr) {
+            g_error_free(err);
+        }
+        if (dbg != nullptr) {
+            g_free(dbg);
+        }
+        gst_message_unref(msg);
+    }
+    gst_object_unref(bus);
 }
 
 Result CameraCapture::start(
     std::function<void(std::unique_ptr<Frame>)> frameCallback) {
-    if (formatCtx_ == nullptr) {
-        return Result::ErrorInitFailed; // Not initialized
+    if (pipeline_ == nullptr) {
+        return Result::ErrorInitFailed;
     }
-    if (isRunning()) {
-        return Result::ErrorInitFailed; // Already running
+    if (running_.load(std::memory_order_relaxed) || captureThread_.joinable()) {
+        return Result::ErrorInitFailed;
     }
 
     frameCallback_ = std::move(frameCallback);
 
+    GstStateChangeReturn ret =
+        gst_element_set_state(pipeline_, GST_STATE_PLAYING);
+    if (ret == GST_STATE_CHANGE_FAILURE) {
+        logPipelineError(pipeline_);
+        std::cerr << "[CameraCapture] failed to set pipeline to PLAYING\n";
+        gst_element_set_state(pipeline_, GST_STATE_NULL);
+        return Result::ErrorCaptureFailed;
+    }
+
+    // Wait up to 5 s for the pipeline to reach PLAYING.
+    GstState state = GST_STATE_NULL;
+    ret = gst_element_get_state(pipeline_, &state, nullptr,
+                                static_cast<GstClockTime>(5) * GST_SECOND);
+    if (ret == GST_STATE_CHANGE_FAILURE || state != GST_STATE_PLAYING) {
+        logPipelineError(pipeline_);
+        std::cerr << "[CameraCapture] pipeline failed to reach PLAYING state "
+                     "(reached: "
+                  << gst_element_state_get_name(state) << ")\n";
+        gst_element_set_state(pipeline_, GST_STATE_NULL);
+        return Result::ErrorCaptureFailed;
+    }
+
+    running_.store(true, std::memory_order_relaxed);
     captureThread_ = std::jthread(
         [this](const std::stop_token &token) { captureLoop(token); });
+
     return Result::Success;
 }
 
 Result CameraCapture::stop() {
+    if (!running_.load(std::memory_order_relaxed)) {
+        return Result::Success;
+    }
+
+    running_.store(false, std::memory_order_relaxed);
+
     if (captureThread_.joinable()) {
         captureThread_.request_stop();
         captureThread_.join();
     }
-    return Result::Success;
-}
 
-int CameraCapture::getWidth() const {
-    return codecCtx_ != nullptr ? codecCtx_->width : 0;
-}
-
-int CameraCapture::getHeight() const {
-    return codecCtx_ != nullptr ? codecCtx_->height : 0;
-}
-
-int CameraCapture::getFramerate() const {
-    return codecCtx_ != nullptr ? codecCtx_->framerate.num : 0;
-}
-
-Result CameraCapture::setupDevice() {
-    avdevice_register_all();
-
-    const AVInputFormat *input_fmt =
-        av_find_input_format(config_.inputFormat.c_str());
-    if (input_fmt == nullptr) {
-        return Result::ErrorInvalidParameter;
-    }
-
-    AVDictionary *options = nullptr;
-    if (config_.width > 0 && config_.height > 0) {
-        std::string video_size = std::to_string(config_.width) + "x" +
-                                 std::to_string(config_.height);
-        av_dict_set(&options, "video_size", video_size.c_str(), 0);
-    }
-    if (config_.framerate > 0) {
-        av_dict_set(&options, "framerate",
-                    std::to_string(config_.framerate).c_str(), 0);
-    }
-
-    if (!config_.pixelFormat.empty()) {
-        av_dict_set(&options, "input_format", 
-                    config_.pixelFormat.c_str(), 0);
-    }
-
-    formatCtx_ = avformat_alloc_context();
-    if (avformat_open_input(&formatCtx_, config_.devicePath.c_str(), input_fmt,
-                            &options) < 0) {
-        av_dict_free(&options);
-        return Result::ErrorDeviceNotFound;
-    }
-    av_dict_free(&options);
-
-    if (avformat_find_stream_info(formatCtx_, nullptr) < 0) {
-        return Result::ErrorInitFailed;
-    }
-
-    // Find video stream
-    for (unsigned i = 0; i < formatCtx_->nb_streams; i++) {
-        if (formatCtx_->streams[i]->codecpar->codec_type ==
-            AVMEDIA_TYPE_VIDEO) {
-            videoStreamIdx_ = static_cast<int>(i);
-            break;
-        }
-    }
-
-    // If no video stream found, return error
-    if (videoStreamIdx_ == -1) {
-        return Result::ErrorDeviceNotFound;
+    if (pipeline_ != nullptr) {
+        gst_element_set_state(pipeline_, GST_STATE_NULL);
     }
 
     return Result::Success;
-}
-
-Result CameraCapture::setupCodec() {
-    if (videoStreamIdx_ == -1) {
-        return Result::ErrorInitFailed; // No video stream
-    }
-
-    auto *codecpar = formatCtx_->streams[videoStreamIdx_]->codecpar;
-    const AVCodec *decoder = avcodec_find_decoder(codecpar->codec_id);
-    if (decoder == nullptr) {
-        return Result::ErrorInitFailed; // Decoder not found
-    }
-
-    codecCtx_ = avcodec_alloc_context3(decoder);
-    if (codecCtx_ == nullptr) {
-        return Result::ErrorInitFailed; // Could not allocate codec context
-    }
-
-    if (avcodec_parameters_to_context(codecCtx_, codecpar) < 0) {
-        return Result::ErrorInitFailed; // Could not copy codec parameters
-    }
-
-    if (avcodec_open2(codecCtx_, decoder, nullptr) < 0) {
-        return Result::ErrorInitFailed;
-    }
-    return Result::Success;
-}
-
-bool CameraCapture::processFrame(AVFrame *frame) {
-    auto wrapped_frame = std::make_unique<Frame>();
-    wrapped_frame->frame.reset(av_frame_clone(frame));
-
-    AVRational stream_tb = formatCtx_->streams[videoStreamIdx_]->time_base;
-    constexpr AVRational ns_tb = {1, 1000000000};
-    wrapped_frame->pts = (frame->pts != AV_NOPTS_VALUE)
-                             ? av_rescale_q(frame->pts, stream_tb, ns_tb)
-                             : 0;
-
-    wrapped_frame->width = frame->width;
-    wrapped_frame->height = frame->height;
-    wrapped_frame->format = static_cast<AVPixelFormat>(frame->format);
-
-    if (frameCallback_) {
-        frameCallback_(std::move(wrapped_frame));
-    }
-
-    av_frame_unref(frame);
-    return true;
-}
-
-bool CameraCapture::processPacket(AVPacket *packet, AVFrame *frame) {
-    if (packet->stream_index != videoStreamIdx_) {
-        return false;
-    }
-    if (avcodec_send_packet(codecCtx_, packet) != 0) {
-        return false;
-    }
-    if (avcodec_receive_frame(codecCtx_, frame) != 0) {
-        return false;
-    }
-    return processFrame(frame);
 }
 
 void CameraCapture::captureLoop(const std::stop_token &stopToken) {
-    AVPacket *packet = av_packet_alloc();
-    AVFrame *frame = av_frame_alloc();
+    // 100 ms pull timeout expressed in nanoseconds.
+    constexpr GstClockTime kPullTimeoutNs = 100 * GST_MSECOND;
 
     while (!stopToken.stop_requested()) {
-        if (av_read_frame(formatCtx_, packet) >= 0) {
-            processPacket(packet, frame);
-            av_packet_unref(packet);
+        GstSample *sample = gst_app_sink_try_pull_sample(GST_APP_SINK(appsink_),
+                                                         kPullTimeoutNs);
+
+        if (sample == nullptr) {
+            // Timeout or EOS — check the bus for a hard error before looping.
+            GstBus *bus = gst_element_get_bus(pipeline_);
+            if (bus != nullptr) {
+                GstMessage *msg = gst_bus_pop_filtered(
+                    bus, static_cast<GstMessageType>(GST_MESSAGE_ERROR |
+                                                     GST_MESSAGE_EOS));
+                if (msg != nullptr) {
+                    if (GST_MESSAGE_TYPE(msg) == GST_MESSAGE_ERROR) {
+                        GError *err = nullptr;
+                        gchar *dbg = nullptr;
+                        gst_message_parse_error(msg, &err, &dbg);
+                        std::cerr << "[CameraCapture] pipeline error: "
+                                  << (err != nullptr ? err->message : "unknown")
+                                  << " | " << (dbg != nullptr ? dbg : "")
+                                  << "\n";
+                        if (err != nullptr) {
+                            g_error_free(err);
+                        }
+                        if (dbg != nullptr) {
+                            g_free(dbg);
+                        }
+                    }
+                    gst_message_unref(msg);
+                    gst_object_unref(bus);
+                    break;
+                }
+                gst_object_unref(bus);
+            }
+            continue;
         }
-        else {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+        GstCaps *caps = gst_sample_get_caps(sample);
+        GstBuffer *buffer = gst_sample_get_buffer(sample);
+
+        if (caps == nullptr || buffer == nullptr) {
+            gst_sample_unref(sample);
+            continue;
+        }
+
+        GstVideoInfo vinfo;
+        if (!gst_video_info_from_caps(&vinfo, caps)) {
+            std::cerr << "[CameraCapture] gst_video_info_from_caps failed\n";
+            gst_sample_unref(sample);
+            continue;
+        }
+
+        GstVideoFrame vframe;
+        if (!gst_video_frame_map(&vframe, &vinfo, buffer, GST_MAP_READ)) {
+            std::cerr << "[CameraCapture] gst_video_frame_map failed\n";
+            gst_sample_unref(sample);
+            continue;
+        }
+
+        // Allocate an AVFrame to hand off to the rest of the pipeline.
+        AVFrame *avf = av_frame_alloc();
+        if (avf == nullptr) {
+            gst_video_frame_unmap(&vframe);
+            gst_sample_unref(sample);
+            continue;
+        }
+
+        avf->format = AV_PIX_FMT_YUV420P;
+        avf->width = GST_VIDEO_FRAME_WIDTH(&vframe);
+        avf->height = GST_VIDEO_FRAME_HEIGHT(&vframe);
+
+        if (av_frame_get_buffer(avf, 32) < 0) {
+            std::cerr << "[CameraCapture] av_frame_get_buffer failed\n";
+            av_frame_free(&avf);
+            gst_video_frame_unmap(&vframe);
+            gst_sample_unref(sample);
+            continue;
+        }
+
+        // Copy the three YUV planes row-by-row, guarding against stride
+        // mismatches.
+        for (int plane = 0; plane < 3; ++plane) {
+            const int srcStride = GST_VIDEO_FRAME_PLANE_STRIDE(&vframe, plane);
+            const int dstStride = avf->linesize[plane];
+            const int planeHeight =
+                (plane == 0) ? avf->height : (avf->height + 1) / 2;
+            const int copyWidth = std::min(srcStride, dstStride);
+
+            const auto *src = static_cast<const uint8_t *>(
+                GST_VIDEO_FRAME_PLANE_DATA(&vframe, plane));
+            uint8_t *dst = avf->data[plane];
+
+            for (int row = 0; row < planeHeight; ++row) {
+                std::memcpy(dst + row * dstStride, src + row * srcStride,
+                            static_cast<std::size_t>(copyWidth));
+            }
+        }
+
+        // PTS from the GStreamer buffer, in nanoseconds.
+        GstClockTime bufPts = GST_BUFFER_PTS(buffer);
+        avf->pts =
+            GST_CLOCK_TIME_IS_VALID(bufPts) ? static_cast<int64_t>(bufPts) : 0;
+
+        gst_video_frame_unmap(&vframe);
+        gst_sample_unref(sample);
+
+        auto wrapped = std::make_unique<Frame>();
+        wrapped->frame.reset(avf);
+        wrapped->pts = avf->pts;
+        wrapped->width = avf->width;
+        wrapped->height = avf->height;
+        wrapped->format = AV_PIX_FMT_YUV420P;
+
+        if (frameCallback_) {
+            frameCallback_(std::move(wrapped));
         }
     }
 
-    av_frame_free(&frame);
-    av_packet_free(&packet);
+    running_.store(false, std::memory_order_relaxed);
 }
 
 } // namespace videoCore::capture

--- a/video-core/src/capture/camera_capture.cpp
+++ b/video-core/src/capture/camera_capture.cpp
@@ -12,6 +12,7 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 }
 
+// NOLINTBEGIN(cppcoreguidelines-pro-type-cstyle-cast, bugprone-casting-through-void, cppcoreguidelines-pro-bounds-constant-array-index, clang-analyzer-optin.core.EnumCastOutOfRange, readability-implicit-bool-conversion)
 namespace videoCore::capture {
 
 CameraCapture::~CameraCapture() {
@@ -116,18 +117,18 @@ Result CameraCapture::buildPipeline() {
                              raw_caps + " ! " + sink_props);
     }
 
-    for (const auto &pipelineStr : candidates) {
-        std::cerr << "[CameraCapture] trying: " << pipelineStr << "\n";
+    for (const auto &pipeline_str : candidates) {
+        std::cerr << "[CameraCapture] trying: " << pipeline_str << "\n";
 
-        GError *parseErr = nullptr;
-        GstElement *pipeline = gst_parse_launch(pipelineStr.c_str(), &parseErr);
-        if (parseErr != nullptr || pipeline == nullptr) {
+        GError *parse_err = nullptr;
+        GstElement *pipeline = gst_parse_launch(pipeline_str.c_str(), &parse_err);
+        if (parse_err != nullptr || pipeline == nullptr) {
             std::cerr << "[CameraCapture] parse error: "
-                      << (parseErr != nullptr ? parseErr->message
+                      << (parse_err != nullptr ? parse_err->message
                                               : "null pipeline")
                       << "\n";
-            if (parseErr != nullptr) {
-                g_error_free(parseErr);
+            if (parse_err != nullptr) {
+                g_error_free(parse_err);
             }
             if (pipeline != nullptr) {
                 gst_object_unref(pipeline);
@@ -173,18 +174,17 @@ Result CameraCapture::buildPipeline() {
             GstMessage *msg = gst_bus_timed_pop_filtered(bus, 500 * GST_MSECOND,
                                                          GST_MESSAGE_ERROR);
             if (msg != nullptr) {
-                GError *busErr = nullptr;
+                GError *bus_err = nullptr;
                 gchar *dbg = nullptr;
-                gst_message_parse_error(msg, &busErr, &dbg);
+                gst_message_parse_error(msg, &bus_err, &dbg);
                 std::cerr << "[CameraCapture] error: "
-                          << (busErr != nullptr ? busErr->message : "?");
-
+                          << (bus_err != nullptr ? bus_err->message : "?");
                 if (dbg != nullptr) {
                     std::cerr << " | " << dbg;
                 }
                 std::cerr << "\n";
-                if (busErr != nullptr) {
-                    g_error_free(busErr);
+                if (bus_err != nullptr) {
+                    g_error_free(bus_err);
                 }
                 if (dbg != nullptr) {
                     g_free(dbg);
@@ -388,7 +388,7 @@ void CameraCapture::captureLoop(const std::stop_token &stopToken) {
             uint8_t *dst = avf->data[plane];
 
             for (int row = 0; row < plane_height; ++row) {
-                std::memcpy(dst + row * dst_stride, src + row * src_stride,
+                std::memcpy(dst + (static_cast<ptrdiff_t>(row) * dst_stride), src + (static_cast<ptrdiff_t>(row) * src_stride),
                             static_cast<std::size_t>(copy_width));
             }
         }
@@ -417,3 +417,4 @@ void CameraCapture::captureLoop(const std::stop_token &stopToken) {
 }
 
 } // namespace videoCore::capture
+// NOLINTEND(cppcoreguidelines-pro-type-cstyle-cast, bugprone-casting-through-void, cppcoreguidelines-pro-bounds-constant-array-index, clang-analyzer-optin.core.EnumCastOutOfRange, readability-implicit-bool-conversion)

--- a/video-core/src/decode/decoder.cpp
+++ b/video-core/src/decode/decoder.cpp
@@ -18,7 +18,7 @@ int64_t Decoder::rescaleToNs(int64_t value, AVRational src_tb) {
     if (value == AV_NOPTS_VALUE) {
         return 0;
     }
-    constexpr AVRational ns_tb = {1, 1000000000};
+    constexpr AVRational ns_tb = {.num = 1, .den = 1000000000};
     return av_rescale_q(value, src_tb, ns_tb);
 }
 

--- a/video-core/src/encode/encoder.cpp
+++ b/video-core/src/encode/encoder.cpp
@@ -22,7 +22,7 @@ int64_t Encoder::rescaleToNs(int64_t value, AVRational src_tb) {
     if (value == AV_NOPTS_VALUE) {
         return 0;
     }
-    constexpr AVRational ns_tb = {1, 1000000000};
+    constexpr AVRational ns_tb = {.num = 1, .den = 1000000000};
     return av_rescale_q(value, src_tb, ns_tb);
 }
 

--- a/video-core/src/encode/nvenc_encoder.cpp
+++ b/video-core/src/encode/nvenc_encoder.cpp
@@ -48,7 +48,7 @@ Result NVENCEncoder::initialize(
     codecCtx_->time_base = AVRational{1, config_.framerate};
     codecCtx_->framerate = AVRational{config_.framerate, 1};
     codecCtx_->gop_size = config_.gopSize;
-    codecCtx_->max_b_frames = 0;          // No B-frames for low latency
+    codecCtx_->max_b_frames = 0;             // No B-frames for low latency
     codecCtx_->pix_fmt = AV_PIX_FMT_YUV420P; // Match camera capture output
 
     // Set preset options (e.g., ultrafast, fast, medium, slow)
@@ -92,8 +92,7 @@ Result NVENCEncoder::encodeFrame(AVFrame *frame) {
 
     if (frame->format != codecCtx_->pix_fmt ||
         frame->width != codecCtx_->width ||
-        frame->height != codecCtx_->height ||
-        frame->linesize[0] == 0) {
+        frame->height != codecCtx_->height || frame->linesize[0] == 0) {
         converted_frame = av_frame_alloc();
         converted_frame->width = codecCtx_->width;
         converted_frame->height = codecCtx_->height;

--- a/video-core/src/encode/nvenc_encoder.cpp
+++ b/video-core/src/encode/nvenc_encoder.cpp
@@ -120,7 +120,7 @@ Result NVENCEncoder::encodeFrame(AVFrame *frame) {
     input_frame->pts =
         av_rescale_q(frame->pts, // already nanoseconds from CameraCapture
                      AVRational{.num = 1, .den = 1000000000}, // from
-                     codecCtx_->time_base       // to encoder timebase
+                     codecCtx_->time_base // to encoder timebase
         );
 
     // Send frame to encoder

--- a/video-core/src/encode/nvenc_encoder.cpp
+++ b/video-core/src/encode/nvenc_encoder.cpp
@@ -49,7 +49,7 @@ Result NVENCEncoder::initialize(
     codecCtx_->framerate = AVRational{config_.framerate, 1};
     codecCtx_->gop_size = config_.gopSize;
     codecCtx_->max_b_frames = 0;          // No B-frames for low latency
-    codecCtx_->pix_fmt = AV_PIX_FMT_NV12; // Common pixel format
+    codecCtx_->pix_fmt = AV_PIX_FMT_YUV420P; // Match camera capture output
 
     // Set preset options (e.g., ultrafast, fast, medium, slow)
     AVDictionary *options = nullptr;
@@ -90,18 +90,21 @@ Result NVENCEncoder::encodeFrame(AVFrame *frame) {
     AVFrame *input_frame = frame;
     AVFrame *converted_frame = nullptr;
 
-    if (frame->format != AV_PIX_FMT_YUV420P || frame->linesize[0] == 0) {
+    if (frame->format != codecCtx_->pix_fmt ||
+        frame->width != codecCtx_->width ||
+        frame->height != codecCtx_->height ||
+        frame->linesize[0] == 0) {
         converted_frame = av_frame_alloc();
         converted_frame->width = codecCtx_->width;
         converted_frame->height = codecCtx_->height;
-        converted_frame->format = AV_PIX_FMT_YUV420P;
+        converted_frame->format = codecCtx_->pix_fmt;
         av_frame_get_buffer(converted_frame, 32);
 
         // Convert to YUV420P if needed
         SwsContext *sws_ctx = sws_getContext(
             frame->width, frame->height,
             static_cast<AVPixelFormat>(frame->format), codecCtx_->width,
-            codecCtx_->height, AV_PIX_FMT_YUV420P, SWS_BILINEAR, nullptr,
+            codecCtx_->height, codecCtx_->pix_fmt, SWS_BILINEAR, nullptr,
             nullptr, nullptr);
 
         // Perform conversion if swsCtx is valid

--- a/video-core/src/encode/nvenc_encoder.cpp
+++ b/video-core/src/encode/nvenc_encoder.cpp
@@ -45,8 +45,8 @@ Result NVENCEncoder::initialize(
     codecCtx_->width = config_.width;
     codecCtx_->height = config_.height;
     codecCtx_->bit_rate = config_.bitrate;
-    codecCtx_->time_base = AVRational{1, config_.framerate};
-    codecCtx_->framerate = AVRational{config_.framerate, 1};
+    codecCtx_->time_base = AVRational{.num = 1, .den = config_.framerate};
+    codecCtx_->framerate = AVRational{.num = config_.framerate, .den = 1};
     codecCtx_->gop_size = config_.gopSize;
     codecCtx_->max_b_frames = 0;             // No B-frames for low latency
     codecCtx_->pix_fmt = AV_PIX_FMT_YUV420P; // Match camera capture output
@@ -119,7 +119,7 @@ Result NVENCEncoder::encodeFrame(AVFrame *frame) {
     // Convert PTS from nanoseconds to encoder timebase
     input_frame->pts =
         av_rescale_q(frame->pts, // already nanoseconds from CameraCapture
-                     AVRational{1, 1000000000}, // from
+                     AVRational{.num = 1, .den = 1000000000}, // from
                      codecCtx_->time_base       // to encoder timebase
         );
 

--- a/video-core/src/encode/software_encoder.cpp
+++ b/video-core/src/encode/software_encoder.cpp
@@ -44,8 +44,8 @@ Result SoftwareEncoder::initialize(
     codecCtx_->width = config_.width;
     codecCtx_->height = config_.height;
     codecCtx_->bit_rate = config_.bitrate;
-    codecCtx_->time_base = AVRational{1, config_.framerate};
-    codecCtx_->framerate = AVRational{config_.framerate, 1};
+    codecCtx_->time_base = AVRational{.num = 1, .den = config_.framerate};
+    codecCtx_->framerate = AVRational{.num = config_.framerate, .den = 1};
     codecCtx_->gop_size = config_.gopSize;
     codecCtx_->max_b_frames = 0;               // No B-frames for low latency
     codecCtx_->pix_fmt = AV_PIX_FMT_YUV420P;   // Common pixel format
@@ -165,7 +165,7 @@ Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
     // Convert PTS from nanoseconds to encoder timebase
     input_frame->pts =
         av_rescale_q(frame->pts, // already nanoseconds from CameraCapture
-                     AVRational{1, 1000000000}, // from
+                     AVRational{.num = 1, .den = 1000000000}, // from
                      codecCtx_->time_base       // to encoder timebase
         );
 

--- a/video-core/src/encode/software_encoder.cpp
+++ b/video-core/src/encode/software_encoder.cpp
@@ -97,6 +97,7 @@ Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
         return Result::ErrorEncodeFailed; // Not initialized
     }
 
+    
     auto src_fmt = static_cast<AVPixelFormat>(frame->format);
     bool src_full_range = (frame->color_range == AVCOL_RANGE_JPEG);
     switch (src_fmt) {

--- a/video-core/src/encode/software_encoder.cpp
+++ b/video-core/src/encode/software_encoder.cpp
@@ -47,14 +47,14 @@ Result SoftwareEncoder::initialize(
     codecCtx_->time_base = AVRational{1, config_.framerate};
     codecCtx_->framerate = AVRational{config_.framerate, 1};
     codecCtx_->gop_size = config_.gopSize;
-    codecCtx_->max_b_frames = 0;             // No B-frames for low latency
-    codecCtx_->pix_fmt = AV_PIX_FMT_YUV420P; // Common pixel format
+    codecCtx_->max_b_frames = 0;               // No B-frames for low latency
+    codecCtx_->pix_fmt = AV_PIX_FMT_YUV420P;   // Common pixel format
     codecCtx_->color_range = AVCOL_RANGE_MPEG; // 16-235/16-240 range
-    #ifdef AV_PROFILE_H264_CONSTRAINED_BASELINE
-        codecCtx_->profile = AV_PROFILE_H264_CONSTRAINED_BASELINE;
-    #else
-        codecCtx_->profile = FF_PROFILE_H264_CONSTRAINED_BASELINE;
-    #endif
+#ifdef AV_PROFILE_H264_CONSTRAINED_BASELINE
+    codecCtx_->profile = AV_PROFILE_H264_CONSTRAINED_BASELINE;
+#else
+    codecCtx_->profile = FF_PROFILE_H264_CONSTRAINED_BASELINE;
+#endif
 
     // Set preset options (e.g., ultrafast, fast, medium, slow)
     AVDictionary *options = nullptr;
@@ -97,34 +97,32 @@ Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
         return Result::ErrorEncodeFailed; // Not initialized
     }
 
-    
     auto src_fmt = static_cast<AVPixelFormat>(frame->format);
     bool src_full_range = (frame->color_range == AVCOL_RANGE_JPEG);
     switch (src_fmt) {
-        case AV_PIX_FMT_YUVJ420P:
-            src_fmt = AV_PIX_FMT_YUV420P;
-            src_full_range = true;
-            break;
-        case AV_PIX_FMT_YUVJ422P:
-            src_fmt = AV_PIX_FMT_YUV422P;
-            src_full_range = true;
-            break;
-        case AV_PIX_FMT_YUVJ444P:
-            src_fmt = AV_PIX_FMT_YUV444P;
-            src_full_range = true;
-            break;
-        default: break;
+    case AV_PIX_FMT_YUVJ420P:
+        src_fmt = AV_PIX_FMT_YUV420P;
+        src_full_range = true;
+        break;
+    case AV_PIX_FMT_YUVJ422P:
+        src_fmt = AV_PIX_FMT_YUV422P;
+        src_full_range = true;
+        break;
+    case AV_PIX_FMT_YUVJ444P:
+        src_fmt = AV_PIX_FMT_YUV444P;
+        src_full_range = true;
+        break;
+    default:
+        break;
     }
 
     // Convert frame to YUV420P with limited range if needed
     AVFrame *input_frame = frame;
     AVFrame *converted_frame = nullptr;
 
-    if (src_fmt != AV_PIX_FMT_YUV420P ||
-        src_full_range ||
+    if (src_fmt != AV_PIX_FMT_YUV420P || src_full_range ||
         frame->width != codecCtx_->width ||
-        frame->height != codecCtx_->height ||
-        frame->linesize[0] == 0) {
+        frame->height != codecCtx_->height || frame->linesize[0] == 0) {
         converted_frame = av_frame_alloc();
         converted_frame->width = codecCtx_->width;
         converted_frame->height = codecCtx_->height;
@@ -133,19 +131,22 @@ Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
 
         // Convert to YUV420P if needed
         SwsContext *sws_ctx = sws_getContext(
-            frame->width, frame->height, src_fmt,
-            codecCtx_->width, codecCtx_->height, AV_PIX_FMT_YUV420P, 
-            SWS_BILINEAR, nullptr, nullptr, nullptr);
+            frame->width, frame->height, src_fmt, codecCtx_->width,
+            codecCtx_->height, AV_PIX_FMT_YUV420P, SWS_BILINEAR, nullptr,
+            nullptr, nullptr);
 
         // Perform conversion if swsCtx is valid
         if (sws_ctx != nullptr) {
             if (src_full_range) {
-                // Maps JPEG full-range (0-255) luma/chroma to H.264 limited-range
-                // (16-235 / 16-240) so that the colors are not washed out at the decoder
-                sws_setColorspaceDetails(sws_ctx, 
-                    sws_getCoefficients(SWS_CS_DEFAULT), 1, // full range @ src
-                    sws_getCoefficients(SWS_CS_DEFAULT), 0, // limited range @ destination
-                    0, 1 << 16, 1 << 16);
+                // Maps JPEG full-range (0-255) luma/chroma to H.264
+                // limited-range (16-235 / 16-240) so that the colors are not
+                // washed out at the decoder
+                sws_setColorspaceDetails(sws_ctx,
+                                         sws_getCoefficients(SWS_CS_DEFAULT),
+                                         1, // full range @ src
+                                         sws_getCoefficients(SWS_CS_DEFAULT),
+                                         0, // limited range @ destination
+                                         0, 1 << 16, 1 << 16);
             }
             sws_scale(sws_ctx, frame->data, frame->linesize, 0, frame->height,
                       converted_frame->data, converted_frame->linesize);

--- a/video-core/src/encode/software_encoder.cpp
+++ b/video-core/src/encode/software_encoder.cpp
@@ -50,7 +50,11 @@ Result SoftwareEncoder::initialize(
     codecCtx_->max_b_frames = 0;             // No B-frames for low latency
     codecCtx_->pix_fmt = AV_PIX_FMT_YUV420P; // Common pixel format
     codecCtx_->color_range = AVCOL_RANGE_MPEG; // 16-235/16-240 range
-    codecCtx_->profile = FF_PROFILE_H264_CONSTRAINED_BASELINE; // For WebRTC
+    #ifdef AV_PROFILE_H264_CONSTRAINED_BASELINE
+        codecCtx_->profile = AV_PROFILE_H264_CONSTRAINED_BASELINE;
+    #else
+        codecCtx_->profile = FF_PROFILE_H264_CONSTRAINED_BASELINE;
+    #endif
 
     // Set preset options (e.g., ultrafast, fast, medium, slow)
     AVDictionary *options = nullptr;

--- a/video-core/src/encode/software_encoder.cpp
+++ b/video-core/src/encode/software_encoder.cpp
@@ -166,7 +166,7 @@ Result SoftwareEncoder::encodeFrame(AVFrame *frame) {
     input_frame->pts =
         av_rescale_q(frame->pts, // already nanoseconds from CameraCapture
                      AVRational{.num = 1, .den = 1000000000}, // from
-                     codecCtx_->time_base       // to encoder timebase
+                     codecCtx_->time_base // to encoder timebase
         );
 
     // Send frame to encoder

--- a/video-core/src/pipeline/video_pipeline.cpp
+++ b/video-core/src/pipeline/video_pipeline.cpp
@@ -80,7 +80,8 @@ void VideoPipeline::requestKeyframe() noexcept {
     }
 }
 
-void VideoPipeline::setPreviewCallback(std::function<void(const Frame &)> previewCallback) {
+void VideoPipeline::setPreviewCallback(
+    std::function<void(const Frame &)> previewCallback) {
     previewCallback_ = std::move(previewCallback);
 }
 

--- a/video-core/src/pipeline/video_pipeline.cpp
+++ b/video-core/src/pipeline/video_pipeline.cpp
@@ -54,7 +54,8 @@ Result VideoPipeline::start(
                 if (previewCallback_) {
                     previewCallback_(*frame);
                 }
-                std::lock_guard<std::mutex> lock(queueMutex_);
+                std::lock_guard<std::mutex> lock(
+                    queueMutex_); // NOLINT(modernize-use-scoped-lock)
                 if (frameQueue_.size() >= QUEUE_CAPACITY) {
                     frameQueue_.pop(); // Drop oldest frame
                     framesDropped_++;

--- a/video-core/tests/unit/decode/test_decoder.cpp
+++ b/video-core/tests/unit/decode/test_decoder.cpp
@@ -34,8 +34,8 @@ static EncodedTestData generateTestPackets(int frameCount = 5) {
 
     ctx->width = result.width;
     ctx->height = result.height;
-    ctx->time_base = {1, result.framerate};
-    ctx->framerate = {result.framerate, 1};
+    ctx->time_base = {.num = 1, .den = result.framerate};
+    ctx->framerate = {.num = result.framerate, .den = 1};
     ctx->pix_fmt = AV_PIX_FMT_YUV420P;
     ctx->gop_size = 1; // every frame is a keyframe — simplifies decoder test
 


### PR DESCRIPTION
## Summary
Fixes end-to-end video streaming pipeline. Operator camera feed now appears 
correctly on the director side.

## Changes

**`video-core/src/capture/camera_capture.cpp`**
- Replaced FFmpeg-based v4l2 capture with GStreamer pipeline using `v4l2src` 
and `appsink`
- Added automatic pipeline candidate probing — tries MJPEG first, falls back 
to raw YUV, then PipeWire variants if available
- Fixed pixel format handling with correct row-by-row plane copy guarding 
against stride mismatches
- Fixed PTS to use GStreamer buffer timestamps directly in nanoseconds

**`networking/src/whip_publisher.cpp` / `networking/include/whip_publisher.hpp`**
- Fixed whipsink pad request to use explicit RTP caps
- Added `use-link-headers` and STUN fallback for ICE negotiation
- Fixed absolute PTS bug — normalized v4l2 device-relative timestamps to 
pipeline-relative time, eliminating scheduling delay at LiveKit ingress
- Added 20s async state change wait for WHIP handshake
- Added mutex around `appsrc_` access to prevent race between `pushPacket` 
and `stop()`
- Fixed buffer leak in `pushPacket` when `appsrc_` is null
- Added `forceKeyframeCallback_` for RTCP PLI/FIR keyframe recovery
- Fixed bus watch removal order in `stop()`

Closes #209 
Closes #204 
Closes #190 